### PR TITLE
Restyle landing page with white theme and single pricing block

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,22 +11,22 @@
   <!-- SEO MEJORADO -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <title>Reclamación de factura eléctrica y gas | TuReclamoExprés</title>
-  <meta name="description" content="TuReclamoExprés es tu aliado en la reclamación de factura eléctrica y gas. Revisamos gratis, incluimos estudio energético certificado y gestionamos tu devolución desde 39,99 €." />
+  <title>Reclamación de facturas de luz y gas – TuReclamoExprés</title>
+  <meta name="description" content="Revisamos gratis tu factura y reclamamos los cobros indebidos por ti. Gestión completa desde 39,99 €, fondo blanco profesional y resultado en 24–48 h." />
   <meta name="keywords" content="reclamación de factura eléctrica y gas, reclamar factura de luz, reclamar factura de gas, cobros indebidos, estudio energético certificado" />
   <meta name="robots" content="index,follow" />
   <meta name="theme-color" content="#ffffff" />
   <link rel="canonical" href="https://tureclamoexpres.com/" />
   <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
   <!-- Open Graph / Twitter -->
-  <meta property="og:title" content="Reclamación de factura eléctrica y gas | TuReclamoExprés" />
-  <meta property="og:description" content="Especialistas en reclamación de factura eléctrica y gas. Revisión gratuita, estudio energético certificado y gestión de reclamaciones desde 39,99 €." />
+  <meta property="og:title" content="Reclamación de facturas de luz y gas – TuReclamoExprés" />
+  <meta property="og:description" content="Revisamos gratis tu factura y reclamamos los cobros indebidos por ti. Gestión completa desde 39,99 € y resultado en 24–48 h." />
   <meta property="og:image" content="https://tureclamoexpres.com/og-image.jpg" />
   <meta property="og:url" content="https://tureclamoexpres.com" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Reclamación de factura eléctrica y gas | TuReclamoExprés" />
-  <meta name="twitter:description" content="Reclamación de factura eléctrica y gas con revisión gratuita, estudio energético certificado y gestión íntegra desde 39,99 €." />
+  <meta name="twitter:title" content="Reclamación de facturas de luz y gas – TuReclamoExprés" />
+  <meta name="twitter:description" content="Revisamos gratis tu factura y reclamamos los cobros indebidos por ti. Gestión completa desde 39,99 € y resultado en 24–48 h." />
   <meta name="twitter:image" content="https://tureclamoexpres.com/og-image.jpg" />
   <link rel="icon" href="/favicon.ico" />
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -163,606 +163,8 @@
   <!-- Google tag (gtag.js) - GA4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-DPPJ4520K7"></script>
   <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-DPPJ4520K7');</script>
-  <style>
-    html { scroll-behavior: smooth; }
-    :root {
-      --bg: #f6f9ff;
-      --bg2: #ffffff;
-      --card: #ffffff;
-      --text: #072146;
-      --muted: #5f6368;
-      --accent: #003a8c;
-      --link: #1464a5;
-      --border: #e6ecf5;
-      --shadow: 0 8px 24px rgba(7,33,70,.08);
-      --ok: #22c55e;
-      --pill-bg: #eef6ff;
-      --pill-border: #cfe3ff;
-    }
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body {
-      font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-      color: var(--text);
-      line-height: 1.7;
-      font-size: 18px;
-      background: linear-gradient(180deg, var(--bg) 0px, #fdfefe 600px, var(--bg2) 100%);
-    }
-    h1, h2, h3, h4 {
-      font-family: 'Montserrat', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-    }
-    h1 { font-size: clamp(28px, 5vw, 44px); }
-    h2 { font-size: clamp(22px, 3.6vw, 32px); }
-    h3 { font-size: clamp(18px, 3vw, 24px); }
-    header, main, footer { max-width: 1100px; margin: 0 auto; padding: 20px; }
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
-    .skip-link {
-      background: var(--accent);
-      color: #fff;
-      padding: 8px 12px;
-      border-radius: 8px;
-      font-size: 1rem;
-      text-decoration: none;
-      display: block;
-      width: max-content;
-      position: absolute;
-      top: 10px;
-      left: 10px;
-      z-index: 1000;
-    }
-    .skip-link:focus { outline: 2px solid #fff; }
-    .site-header {
-      grid-area: header;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 12px 18px;
-      position: sticky;
-      top: 0;
-      background: #fff;
-      z-index: 999;
-      border-bottom: 1px solid var(--border);
-      box-shadow: 0 2px 10px rgba(7,33,70,.04);
-      border-radius: 0 0 12px 12px;
-    }
-    .logo {
-      font-weight: 800;
-      font-size: 1.45rem;
-      color: var(--text);
-      text-decoration: none;
-      letter-spacing: .2px;
-    }
-    .nav {
-      grid-area: nav;
-      display: flex;
-      align-items: center;
-    }
-    .nav-links {
-      list-style: none;
-      display: flex;
-      gap: 16px;
-    }
-    .nav-links a {
-      color: var(--text);
-      font-weight: 600;
-      text-decoration: none;
-      font-size: .95rem;
-      padding: 8px 10px;
-      border-radius: 10px;
-    }
-    .nav-links a:hover {
-      background: var(--pill-bg);
-      border: 1px solid var(--pill-border);
-    }
-    .nav-toggle {
-      display: none;
-      background: none;
-      border: 0;
-      cursor: pointer;
-    }
-    .nav-toggle-bar {
-      display: block;
-      width: 24px;
-      height: 2px;
-      margin: 5px 0;
-      background: var(--text);
-    }
-    .header-right {
-      display: flex;
-      align-items: center;
-      gap: 16px;
-    }
-    .header-contact {
-      font-size: .95rem;
-      color: var(--muted);
-    }
-    .header-contact a {
-      color: var(--text);
-      text-decoration: none;
-      font-weight: 700;
-    }
-    @media (max-width: 768px) {
-      .nav-toggle { display: block; }
-      .nav {
-        position: fixed;
-        left: 0;
-        right: 0;
-        top: 70px;
-        background: #fff;
-        transform: translateY(-120%);
-        transition: transform .25s ease;
-        height: calc(100vh - 70px);
-        overflow-y: auto;
-        border-top: 1px solid var(--border);
-      }
-      .nav.open { transform: translateY(0); }
-      .nav-links {
-        flex-direction: column;
-        padding: 10px;
-        gap: 6px;
-      }
-      .nav-links li { border-top: 1px solid var(--border); }
-      .nav-links a { padding: 12px 14px; display: block; }
-      .header-contact { display: none; }
-    }
-    .hero {
-      text-align: center;
-      padding: 4rem 1.5rem 3rem;
-    }
-    .hero p {
-      color: var(--muted);
-      max-width: 920px;
-      margin: 0 auto 16px;
-      font-size: 1.08rem;
-    }
-    .trustline {
-      margin-top: .25rem;
-      color: var(--text);
-      font-weight: 700;
-    }
-    .hero .trustline, .hero p:first-of-type {
-      background: var(--pill-bg);
-      border: 1px solid var(--pill-border);
-      border-radius: 14px;
-      padding: 12px 14px;
-    }
-    .btn {
-      display: inline-block;
-      padding: 12px 24px;
-      border-radius: 10px;
-      font-weight: 700;
-      text-decoration: none;
-      margin: 8px;
-      font-size: 1rem;
-      letter-spacing: .2px;
-      box-shadow: var(--shadow);
-      transition: transform .2s ease, background .2s ease;
-    }
-    .btn:hover {
-      transform: scale(1.05);
-      background: #16a34a;
-    }
-    .btn-primary {
-      background: var(--ok);
-      color: #fff;
-      border: 1px solid #16a34a;
-    }
-    .btn-outline {
-      border: 1px solid var(--accent);
-      color: var(--accent);
-      background: #fff;
-    }
-    .btn-whatsapp {
-      background: var(--ok);
-      color: #052e16;
-      border: 1px solid #16a34a;
-    }
-    .media-hero img, .media-grid img, .casos-media img {
-      width: 100%;
-      height: auto;
-      max-height: 240px;
-      object-fit: contain;
-      object-position: center;
-      border-radius: 14px;
-      box-shadow: var(--shadow);
-      background: #fff;
-      padding: 6px;
-    }
-    @media (min-width: 900px) {
-      .media-hero img { max-height: 420px; }
-    }
-    @media (max-width: 600px) {
-      .hero p {
-        background: #fff;
-        border: 1px solid var(--border);
-        border-radius: 12px;
-        padding: 12px;
-      }
-      .hero .btn {
-        width: 100%;
-        max-width: 520px;
-      }
-    }
-    .steps {
-      display: grid;
-      gap: 12px;
-      margin: 18px auto 0;
-      max-width: 920px;
-    }
-    @media (min-width: 900px) {
-      .steps { grid-template-columns: repeat(3, 1fr); }
-    }
-    .step {
-      background: #fff;
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 16px;
-      text-align: left;
-      box-shadow: var(--shadow);
-    }
-    .step b {
-      display: block;
-      font-family: 'Montserrat';
-      font-size: 1.05rem;
-      margin-bottom: 6px;
-    }
-    .toggle {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      width: 100%;
-      background: #fff;
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 14px 16px;
-      color: var(--text);
-      font-weight: 700;
-      cursor: pointer;
-      font-size: 1.05rem;
-    }
-    .toggle+.toggle-wrap {
-      overflow: hidden;
-      max-height: 0;
-      transition: max-height .25s ease;
-    }
-    .toggle-wrap .inner { padding: 12px 2px; }
-    .services {
-      display: grid;
-      gap: 12px;
-    }
-    @media (min-width: 900px) {
-      .services { grid-template-columns: repeat(3, 1fr); }
-    }
-    .svc {
-      background: #fff;
-      padding: 16px;
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      box-shadow: var(--shadow);
-    }
-    .svc h3 {
-      margin: 0 0 .5rem;
-      font-family: 'Montserrat';
-    }
-    .help {
-      color: var(--muted);
-      font-size: .95rem;
-    }
-    .card {
-      background: #fff;
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 16px;
-      box-shadow: var(--shadow);
-    }
-    .plans {
-      display: grid;
-      gap: 12px;
-      margin-top: 8px;
-    }
-    @media (min-width: 900px) {
-      .plans { grid-template-columns: 1fr; }
-    }
-    .plan {
-      background: #fff;
-      padding: 16px;
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      position: relative;
-      box-shadow: var(--shadow);
-    }
-    .plan.recommended {
-      background: linear-gradient(180deg, #f0f7ff, #ffffff);
-      outline: 2px solid var(--accent);
-      transform: translateY(-2px);
-    }
-    .price {
-      font-size: 1.6rem;
-      font-weight: 800;
-      font-family: 'Montserrat';
-      color: var(--text);
-    }
-    .plan .badge {
-      position: absolute;
-      top: -10px;
-      left: 16px;
-      padding: 6px 10px;
-      border-radius: 999px;
-      font-weight: 800;
-      font-size: .85rem;
-      background: var(--accent);
-      color: #fff;
-      border: 1px solid #002a66;
-    }
-    .plan ul li {
-      list-style: none;
-      padding-left: 1.5rem;
-      position: relative;
-    }
-    .plan ul li:before {
-      content: '•';
-      position: absolute;
-      left: 0;
-    }
-    #precios .plan p, #precios .plan li {
-      font-size: 1.05rem;
-      line-height: 1.7;
-    }
-    .trust-badges {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      margin-top: 8px;
-      opacity: .9;
-      flex-wrap: wrap;
-    }
-    .trust-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 6px 10px;
-      border: 1px solid var(--border);
-      border-radius: 999px;
-      font-size: .9rem;
-      color: var(--text);
-      background: #fff;
-    }
-    .testimonials {
-      display: grid;
-      gap: 12px;
-      margin-top: 14px;
-    }
-    @media (min-width: 900px) {
-      .testimonials { grid-template-columns: repeat(3, 1fr); }
-    }
-    .case-card {
-      background: #fff;
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 14px;
-      box-shadow: var(--shadow);
-    }
-    .case-card h3 {
-      font-size: 1.05rem;
-      margin-bottom: 6px;
-    }
-    .case-meta {
-      font-size: .92rem;
-      color: var(--muted);
-      margin: .25rem 0 .5rem;
-    }
-    .legal-note {
-      font-size: .85rem;
-      color: #6b7280;
-      margin-top: 6px;
-    }
-    #confianza {
-      margin-top: 1.6rem;
-      padding: 1rem;
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      background: #fff;
-      box-shadow: var(--shadow);
-    }
-    #confianza ul li {
-      list-style: none;
-      padding-left: 1.5rem;
-      position: relative;
-    }
-    #confianza ul li:before {
-      content: '•';
-      position: absolute;
-      left: 0;
-    }
-    #reclamoForm input, #reclamoForm textarea {
-      width: 100%;
-      margin: 8px 0;
-      padding: 12px 14px;
-      border-radius: 10px;
-      border: 1px solid var(--border);
-      background: #fff;
-      color: var(--text);
-      font-size: 1rem;
-    }
-    #reclamoForm textarea {
-      min-height: 140px;
-      resize: vertical;
-    }
-    #reclamoForm label {
-      display: block;
-      margin: 6px 0;
-      font-weight: 600;
-    }
-    #formOK {
-      color: #16a34a;
-      display: none;
-    }
-    #formERR {
-      color: #b91c1c;
-      display: none;
-    }
-    .footer {
-      grid-area: footer;
-      border-top: 1px solid var(--border);
-      margin-top: 30px;
-      padding: 60px 20px 90px;
-      color: var(--muted);
-    }
-    .footer a { color: var(--link); }
-    #legal-modal {
-      position: fixed;
-      inset: 0;
-      display: none;
-      align-items: center;
-      justify-content: center;
-      background: rgba(0,0,0,.55);
-      z-index: 9999;
-    }
-    .modal-wrap {
-      background: #fff;
-      color: var(--text);
-      width: min(900px, 92vw);
-      max-height: 90vh;
-      border-radius: 10px;
-      overflow-y: auto;
-      padding: 20px;
-      border: 1px solid var(--border);
-      box-shadow: var(--shadow);
-    }
-    .modal-toplinks {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      margin: 8px 0 14px;
-    }
-    .chip {
-      border: 1px solid var(--border);
-      padding: 6px 10px;
-      border-radius: 999px;
-      text-decoration: none;
-      color: var(--text);
-      font-size: .95rem;
-      background: #fff;
-    }
-    .fab-wa {
-      position: fixed;
-      right: 16px;
-      bottom: 80px;
-      z-index: 1000;
-      background: #22c55e;
-      color: #052e16;
-      font-weight: 800;
-      border-radius: 999px;
-      padding: 12px 18px;
-      text-decoration: none;
-      font-size: 1rem;
-      border: 1px solid #16a34a;
-      box-shadow: var(--shadow);
-      animation: pulse 2s infinite;
-    }
-    @keyframes pulse {
-      0% { transform: scale(1); }
-      50% { transform: scale(1.1); }
-      100% { transform: scale(1); }
-    }
-    @media (max-width: 600px) {
-      .fab-wa {
-        bottom: 80px;
-        padding: 10px 16px;
-        font-size: .95rem;
-      }
-    }
-    .media-grid, .casos-media {
-      display: grid;
-      gap: 10px;
-      align-items: start;
-      justify-items: center;
-    }
-    .media-grid img, .casos-media img {
-      max-width: 640px;
-    }
-    @media (max-width: 700px) {
-      .media-grid, .casos-media {
-        grid-template-columns: 1fr;
-      }
-    }
-    @media (min-width: 700px) {
-      .media-grid, .casos-media {
-        grid-template-columns: 1fr 1fr;
-      }
-    }
-    .payment-lock {
-      display: block;
-      margin: 14px auto 0;
-      width: 120px;
-      height: auto;
-      object-fit: contain;
-      opacity: .95;
-    }
-    .banner-lock { padding: 10px 0; }
-    .exit-popup {
-      display: none;
-      position: fixed;
-      inset: 0;
-      background: rgba(0,0,0,.7);
-      z-index: 10000;
-      align-items: center;
-      justify-content: center;
-    }
-    .exit-popup-content {
-      background: #fff;
-      padding: 20px;
-      border-radius: 12px;
-      text-align: center;
-      max-width: 400px;
-      box-shadow: var(--shadow);
-    }
-    .exit-popup-content h2 {
-      font-size: 1.5rem;
-      margin-bottom: 10px;
-    }
-    .exit-popup-content p {
-      font-size: 1rem;
-      color: var(--muted);
-      margin-bottom: 14px;
-    }
-    .faq-section { margin-top: 1.5rem; }
-    .faq-toggle {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      width: 100%;
-      background: #fff;
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 14px 16px;
-      color: var(--text);
-      font-weight: 700;
-      cursor: pointer;
-      font-size: 1.05rem;
-    }
-    .faq-toggle+.faq-wrap {
-      overflow: hidden;
-      max-height: 0;
-      transition: max-height .25s ease;
-    }
-    .faq-wrap .inner { padding: 12px 2px; }
-    #reseñas .btn { margin: 6px; }
-    @media (max-width: 768px) {
-      #reseñas .btn {
-        display: block;
-        width: 100%;
-        margin: 8px 0;
-      }
-    }
-    .free-study {
-      background: #f0f7ff;
-      border: 1px solid #cfe3ff;
-      border-radius: 12px;
-      padding: 20px;
-      margin: 40px 0;
-      text-align: center;
-    }
-  </style>
+  <link rel="stylesheet" href="style.css">
+
 </head>
 <body>
   <a href="#main-content" class="skip-link sr-only">Ir al contenido principal</a>
@@ -795,19 +197,17 @@
     <section class="hero" id="inicio">
       <h1>Reclama los cobros indebidos de tu factura de luz o gas</h1>
       <p class="trustline">Revisamos tu factura y comprobamos si existen errores o importes indebidos. Incluye un <strong>estudio energético certificado gratuito</strong> con tu análisis.</p>
-      <p><strong>Solo si decides reclamar</strong>, gestionamos todo el proceso por ti desde <strong>39,99 €</strong>, con seguimiento completo y resultado en 24–48 h.</p>
-      <p>Sin compromiso, sin letra pequeña y con ahorro real en tu factura.</p>
+      <p><strong>Precio único de 39,99 € IVA incluido</strong> cuando decides reclamar. Seguimiento completo y resultado en 24–48 h.</p>
+      <p>Sin compromiso, sin letra pequeña y con informe certificado en cada revisión.</p>
       <figure class="media-hero" aria-label="Ilustración revisión de factura">
         <img loading="lazy" decoding="async" width="640" height="360" src="hero-mujer-factura.jpg" alt="Mujer revisando una factura de luz con alivio tras recuperar dinero">
       </figure>
       <div>
         <a class="btn btn-primary" href="#revision" aria-label="Solicitar revisión gratuita de factura" aria-describedby="cta-desc">Revisión gratuita de factura</a>
-        <a class="btn btn-outline" href="#precios" aria-label="Ver planes y precios" aria-describedby="cta-desc">Planes y precios</a>
+        <a class="btn btn-outline" href="#precios" aria-label="Consultar el precio único del servicio" aria-describedby="cta-desc">Ver precio único</a>
       </div>
-      <p id="cta-desc" class="sr-only">Inicia la revisión gratuita de tu factura o consulta nuestros planes de reclamación.</p>
-      <p class="help" style="margin-top:18px;color:#0f5132;background:#d1fae5;border:1px solid #86efac;border-radius:10px;padding:12px 14px;">
-        Respuesta profesional en 24–48 h, tratamiento confidencial de datos y pago seguro cuando el servicio lo requiera.
-      </p>
+      <p id="cta-desc" class="sr-only">Inicia la revisión gratuita de tu factura o consulta nuestro precio único para la gestión completa.</p>
+      <p class="help highlight-note">Respuesta profesional en 24–48 h, tratamiento confidencial de datos y pago seguro cuando el servicio lo requiera.</p>
       <div class="trust-badges" aria-label="Reseñas y estadísticas de confianza">
         <span class="trust-badge">Más de 5.000 facturas analizadas</span>
         <span class="trust-badge">Más de 250.000 € recuperados</span>
@@ -828,12 +228,12 @@
         </div>
         <div class="step">
           <b>3. Decide los siguientes pasos</b>
-          Si lo deseas, preparamos y gestionamos la reclamación con el plan que mejor se adapte a tu caso.
+          Si lo deseas, preparamos y gestionamos la reclamación completa con nuestro servicio de precio cerrado.
         </div>
       </div>
     </section>
     <!-- CASOS REALES -->
-    <section id="casos" style="margin-top:1.25rem;">
+    <section id="casos">
       <h2>Casos reales</h2>
       <div class="casos-media" aria-label="Clientes satisfechos">
         <img loading="lazy" decoding="async" width="640" height="360" src="persona-familia.jpg" alt="Familia celebrando la devolución de dinero tras reclamar con TuReclamoExprés">
@@ -841,71 +241,55 @@
       <div class="testimonials">
         <div class="case-card">
           <h3>Iberdrola – 132 € recuperados</h3>
-          <div class="case-meta">Juan G. · Jaén · Potencia mal facturada · Resolución en 10 días · <em>Plan Premium</em></div>
+          <div class="case-meta">Juan G. · Jaén · Potencia mal facturada · Resolución en 10 días · Gestión completa TuReclamoExprés</div>
           <p>Detectamos exceso en término de potencia. Reclamación presentada y aceptada; devolución aplicada en la siguiente factura.</p>
           <div class="legal-note">*Datos anonimizados. Comprobantes disponibles bajo solicitud (acuse difuminado).</div>
         </div>
         <div class="case-card">
           <h3>Naturgy – 2 meses devueltos</h3>
-          <div class="case-meta">María P. · Sevilla · Subida no informada en internet · Respuesta en 14 días · <em>Plan Premium</em></div>
+          <div class="case-meta">María P. · Sevilla · Subida no informada en internet · Respuesta en 14 días · Gestión integral TuReclamoExprés</div>
           <p>Subida unilateral sin notificación válida. Se exigió retroacción de tarifas y devolución de las mensualidades afectadas.</p>
           <div class="legal-note">*Datos anonimizados. Comprobantes disponibles bajo solicitud.</div>
         </div>
         <div class="case-card">
           <h3>Gas – 89 € de ajuste</h3>
-          <div class="case-meta">Pedro R. · Córdoba · Estimaciones incorrectas · Ajuste en la siguiente factura · <em>Plan Estándar</em></div>
+          <div class="case-meta">Pedro R. · Córdoba · Estimaciones incorrectas · Ajuste en la siguiente factura · Servicio administrativo completo</div>
           <p>Estimaciones por encima del consumo real. La compañía corrigió lecturas y abonó el exceso en el ciclo siguiente.</p>
           <div class="legal-note">*Datos anonimizados.</div>
         </div>
       </div>
-      <div style="text-align:center;margin-top:10px;">
+      <div class="cta-group">
         <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión ahora</a>
-        <a class="btn btn-outline" href="#precios" aria-label="Ver planes de precios" aria-describedby="cta-desc">Consultar planes disponibles</a>
+        <a class="btn btn-outline" href="#precios" aria-label="Consultar el precio único del servicio" aria-describedby="cta-desc">Consultar precio único</a>
       </div>
     </section>
     <!-- RESEÑAS GOOGLE -->
-    <section id="reseñas" style="margin-top:1.5rem;text-align:center;">
+    <section id="reseñas">
       <h2>Reseñas</h2>
-      <div style="margin-top:12px;">
+      <div class="spaced-block">
         <script src="https://elfsightcdn.com/platform.js" async></script>
         <div class="elfsight-app-d07b286e-c832-4cfa-b497-e9533c642b82" data-elfsight-app-lazy></div>
       </div>
-      <div style="margin-top:12px;">
+      <div class="spaced-block cta-group">
         <a class="btn btn-primary" href="https://g.page/r/CYf0jfou4O_XEAE/review" target="_blank" rel="noopener" aria-label="Dejar reseña en Google">Escribir reseña en Google</a>
         <a class="btn btn-outline" href="https://g.page/r/CYf0jfou4O_XEAE/review" target="_blank" rel="noopener" aria-label="Ver todas las reseñas en Google">Consultar todas las reseñas</a>
       </div>
     </section>
     <!-- PRECIOS -->
     <section id="precios">
-      <h2>Planes y precios</h2>
-      <p class="help" style="margin:.25rem 0 .75rem">Pagas solo si tu reclamación es viable. Precio único con IVA incluido para elegir el nivel de acompañamiento adecuado.</p>
-      <div class="plans">
-        <div class="plan recommended" aria-label="Plan Premium – Gestión completa por nosotros">
-          <span class="badge">Gestión integral recomendada</span>
-          <div class="price">39,99 €</div>
-          <p><strong>Premium – Lo gestionamos por ti</strong></p>
-          <ul style="margin-left:1rem;">
-            <li>Revisión inicial sin coste y cálculo del importe recuperable</li>
-            <li><strong>Reclamación completa en tu nombre</strong></li>
-            <li><strong>Seguimiento telemático</strong> (respuestas, réplicas, plazos)</li>
-            <li><strong>Información en cada paso</strong> y <strong>confirmación de acuse</strong></li>
-          </ul>
-          <p class="help" style="margin:.4rem 0 0">Delegas cada trámite: elaboramos la reclamación, la presentamos y hacemos seguimiento hasta el cierre.</p>
-          <a class="btn btn-primary" href="https://buy.stripe.com/cNi14o0Ho3Qz93N1QZ8og02" target="_blank" rel="noopener noreferrer" aria-label="Pagar Plan Premium 39,99 €" aria-describedby="cta-desc">Pagar 39,99 €</a>
-          <div class="trust-badges" aria-label="Pago seguro">
-            <span class="trust-badge">Stripe</span>
-            <span class="trust-badge">Visa</span>
-            <span class="trust-badge">Mastercard</span>
-          </div>
-        </div>
+      <div class="precio-unico">
+        <h2>Gestión completa de reclamación</h2>
+        <p><strong>39,99 € IVA incluido</strong></p>
+        <p>Revisión gratuita e informe certificado. Si detectamos cobros indebidos y decides reclamar, gestionamos todo el proceso por ti hasta la resolución final.</p>
+        <ul>
+          <li>Reclamación completa en tu nombre</li>
+          <li>Seguimiento telemático y comunicación continua</li>
+          <li>Resultado en 24–48 h</li>
+        </ul>
+        <a href="#revision" class="btn btn-primary">Iniciar revisión gratuita</a>
       </div>
-      <p class="help" style="margin-top:.75rem;font-size:0.98rem;color:var(--text);">
-        Tu devolución se abona siempre directamente por tu compañía en tu cuenta o factura; nosotros únicamente gestionamos el expediente.
-      </p>
-      <p class="help" style="margin-top:.75rem;font-size:.9rem;color:var(--muted);">
-        Servicio administrativo y automatizado: no constituye asesoramiento jurídico individualizado ni representación letrada.
-        Si tu caso requiere abogado, derivamos —con tu consentimiento— a <strong>colaboradores externos, colegiados y responsables de sus honorarios</strong>.
-      </p>
+      <p class="help">Tu devolución se abona siempre directamente por tu compañía en tu cuenta o factura; nosotros únicamente gestionamos el expediente.</p>
+      <p class="help">Servicio administrativo y automatizado: no constituye asesoramiento jurídico individualizado ni representación letrada. Si tu caso requiere abogado, derivamos —con tu consentimiento— a <strong>colaboradores externos, colegiados y responsables de sus honorarios</strong>.</p>
       <div class="faq-section" aria-label="Preguntas frecuentes">
         <button class="faq-toggle" id="toggleFaq" aria-expanded="false" aria-controls="faqWrap" aria-label="Mostrar u ocultar preguntas frecuentes">
           <span>Preguntas frecuentes</span><span aria-hidden="true">⌄</span>
@@ -927,14 +311,14 @@
           </div>
         </div>
       </div>
-      <div style="text-align:center;margin-top:10px;">
+      <div class="cta-group">
         <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión por WhatsApp</a>
         <a class="btn btn-outline" href="#formulario" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
       </div>
     </section>
     <div id="revision" class="sr-only" aria-hidden="true"></div>
     <!-- FORMULARIO -->
-    <section id="formulario" style="margin-top:18px">
+    <section id="formulario">
       <h2>Contacto y formulario</h2>
       <p class="help">Cuéntanos tu caso y adjunta tu recibo. Revisamos gratis la reclamación de factura eléctrica y gas y te confirmamos el siguiente paso en 24–48 h.</p>
       <form id="reclamoForm" action="https://formspree.io/f/mzzvnwll" method="POST" novalidate>
@@ -956,7 +340,7 @@
       </form>
     </section>
     <!-- QUÉ HACEMOS -->
-    <section id="que-hacemos" style="margin-top:8px;text-align:center">
+    <section id="que-hacemos">
       <h2>Qué hacemos por ti</h2>
       <div class="media-grid" aria-label="Equipo revisando casos">
         <img loading="lazy" decoding="async" width="640" height="360" src="persona-hombre-pc.jpg" alt="Asesor digital preparando una reclamación para recuperar dinero">
@@ -973,7 +357,7 @@
             </div>
             <div class="svc">
               <h3>Reclamaciones por cobros indebidos</h3>
-              <p class="help">Preparamos tu reclamación personalizada con base legal. En Premium, la enviamos por ti, hacemos seguimiento y te confirmamos el acuse.</p>
+              <p class="help">Preparamos tu reclamación personalizada con base legal. Si delegas la gestión completa, la enviamos por ti, hacemos seguimiento y te confirmamos el acuse.</p>
             </div>
             <div class="svc">
               <h3>Telefonía e Internet</h3>
@@ -988,7 +372,7 @@
               <p class="help">Si te ponen trabas para la baja o te han dado de alta sin consentimiento, reclamamos y cortamos continuidad.</p>
             </div>
             <div class="svc">
-              <h3>Seguimiento Premium</h3>
+              <h3>Seguimiento integral</h3>
               <p class="help">Delegas todo: envío, respuestas, réplicas y recordatorios a la entidad hasta cierre del caso.</p>
             </div>
             <div class="svc">
@@ -996,23 +380,23 @@
               <p class="help">Si el caso requiere abogado, derivamos —con tu consentimiento— a colaboradores colegiados (ellos gestionan sus honorarios).</p>
             </div>
           </div>
-            <div style="text-align:center;margin-top:10px;">
-              <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión por WhatsApp</a>
-              <a class="btn btn-outline" href="#formulario" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
-            </div>
+          <div class="cta-group">
+            <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión por WhatsApp</a>
+            <a class="btn btn-outline" href="#formulario" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
+          </div>
         </div>
       </div>
     </section>
     <!-- GUÍAS -->
-    <section id="guias" style="margin:60px 20px;background:#fff;">
-      <div class="wrap" style="max-width:1100px;margin:0 auto">
+    <section id="guias">
+      <div class="wrap">
         <h2>Guías prácticas</h2>
         <button class="faq-toggle" id="toggleGuides" aria-expanded="false" aria-controls="guidesWrap" aria-label="Mostrar u ocultar guías">
           <span>Ver guías</span><span aria-hidden="true">›</span>
         </button>
         <div id="guidesWrap" class="faq-wrap" role="region" aria-label="Listado de guías">
           <div class="inner">
-            <div class="grid grid-2" style="display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));">
+            <div class="grid grid-2">
               <div class="card">
                 <h3>Factura de luz</h3>
                 <p>Detecta cobros indebidos y aprende a reclamar tu recibo de electricidad.</p>
@@ -1034,7 +418,7 @@
                 <a class="btn btn-outline" href="/reclamar-seguro.html" aria-label="Ver guía sobre reclamación de seguros" aria-describedby="cta-desc">Ver guía</a>
               </div>
             </div>
-            <div style="text-align:center;margin-top:10px;">
+            <div class="cta-group">
               <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión por WhatsApp</a>
               <a class="btn btn-outline" href="#formulario" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
             </div>
@@ -1054,9 +438,9 @@
       <img class="payment-lock" loading="lazy" decoding="async" width="120" height="80" src="logo-seguridad-pago.jpg" alt="Ícono de pago seguro con Stripe, Visa y Mastercard">
     </section>
     <!-- CONFIANZA -->
-    <section id="confianza" style="margin-top:1.5rem;padding:1rem;border:1px solid var(--border);border-radius:12px;background:#fff;box-shadow:var(--shadow);">
+    <section id="confianza">
       <h2>Por qué confiar en TuReclamoExprés</h2>
-      <ul style="margin-left:1rem;">
+      <ul>
         <li><strong>Incluye estudio energético certificado</strong> realizado por nuestro equipo especializado.</li>
         <li><strong>Especialistas</strong> en luz, gas y telecomunicaciones.</li>
         <li><strong>Precios cerrados</strong> y comunicación transparente desde el inicio.</li>
@@ -1070,7 +454,7 @@
         <span class="trust-badge">Valoración media 4,8/5</span>
         <span class="trust-badge">Más de 250.000 € recuperados</span>
       </div>
-      <div style="text-align:center;margin-top:10px;">
+      <div class="cta-group">
         <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar estudio energético certificado" rel="noopener" aria-describedby="cta-desc">Solicitar estudio energético</a>
         <a class="btn btn-outline" href="#formulario" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
         <a class="btn btn-primary" href="https://g.page/r/CYf0jfou4O_XEAE/review" target="_blank" rel="noopener" aria-label="Consultar reseñas en Google" aria-describedby="cta-desc">Consultar reseñas en Google</a>
@@ -1100,7 +484,7 @@
       </nav>
       <section id="modal-privacidad">
         <h3>Política de Privacidad</h3>
-        <p>En virtud del RGPD y la LOPDGDD, los datos que los usuarios remitan vía formularios, correo o servicios vinculados se tratarán con la finalidad de revisión gratuita de facturas, elaboración de diagnósticos preliminares y, en su caso, generación y entrega de documentos automatizados. Responsable: S.A.G. Servicios Digitales, email <a href="mailto:info@tureclamoexpres.com" aria-label="Enviar email a info@tureclamoexpres.com">info@tureclamoexpres.com</a>. No se cederán datos a terceros salvo obligación legal o necesidad técnica en modalidad Premium. Derechos de acceso, rectificación, supresión, oposición, limitación y portabilidad mediante solicitud al correo indicado.</p>
+        <p>En virtud del RGPD y la LOPDGDD, los datos que los usuarios remitan vía formularios, correo o servicios vinculados se tratarán con la finalidad de revisión gratuita de facturas, elaboración de diagnósticos preliminares y, en su caso, generación y entrega de documentos automatizados. Responsable: S.A.G. Servicios Digitales, email <a href="mailto:info@tureclamoexpres.com" aria-label="Enviar email a info@tureclamoexpres.com">info@tureclamoexpres.com</a>. No se cederán datos a terceros salvo obligación legal o necesidad técnica en modalidad de gestión completa. Derechos de acceso, rectificación, supresión, oposición, limitación y portabilidad mediante solicitud al correo indicado.</p>
       </section>
       <section id="modal-cookies">
         <h3>Política de Cookies</h3>
@@ -1108,14 +492,14 @@
       </section>
       <section id="modal-condiciones">
         <h3>Condiciones de Servicio</h3>
-        <p>El acceso al sitio implica la aceptación de estas condiciones. El servicio consiste en la revisión inicial gratuita, identificación de cobros indebidos y, en su caso, generación de documentos automatizados que el usuario puede enviar por sí mismo o autorizar su envío en modalidad Premium. La prestación es administrativa y automatizada; no constituye asesoramiento jurídico individualizado ni representación letrada. Precios IVA incluido, pago a través de Stripe. Al ser contenido digital de entrega inmediata, no aplica derecho de desistimiento (art. 103.m TRLGDCU), sin perjuicio de reembolso por incidencias técnicas.</p>
+        <p>El acceso al sitio implica la aceptación de estas condiciones. El servicio consiste en la revisión inicial gratuita, identificación de cobros indebidos y, en su caso, generación de documentos automatizados que el usuario puede enviar por sí mismo o autorizar su envío en modalidad de gestión completa. La prestación es administrativa y automatizada; no constituye asesoramiento jurídico individualizado ni representación letrada. Precios IVA incluido, pago a través de Stripe. Al ser contenido digital de entrega inmediata, no aplica derecho de desistimiento (art. 103.m TRLGDCU), sin perjuicio de reembolso por incidencias técnicas.</p>
       </section>
       <section id="modal-aviso">
         <h3>Aviso Legal</h3>
-        <p class="help" style="margin:.25rem 0 .5rem"><em>TuReclamoExprés se ofrece a título particular. Los datos identificativos se muestran en cumplimiento de la Ley 34/2002 (LSSI).</em></p>
+        <p class="help modal-note"><em>TuReclamoExprés se ofrece a título particular. Los datos identificativos se muestran en cumplimiento de la Ley 34/2002 (LSSI).</em></p>
         <p>Este sitio es titularidad de S.A.G. Servicios Digitales. Objeto: información general y modelos automatizados de reclamación, sin que ello suponga asesoramiento jurídico ni representación letrada. En supuestos que requieran intervención de abogado, podremos derivar —con consentimiento expreso del usuario— a <strong>abogados colaboradores externos, colegiados y responsables de sus honorarios y actuaciones</strong>. A efectos meramente identificativos y de contacto interno del titular del proyecto, se hace constar —sin perjuicio de la razón social anterior— que <em>Sergio Arnes Gómez, DNI 78687563D, C/ Ibañez Marín, Andújar (Jaén), C.P. 23740</em>, participa en la coordinación operativa del servicio, dejando claro que cualquier controversia se someterá a los Juzgados y Tribunales de Jaén, salvo lo dispuesto por normativa de consumidores.</p>
       </section>
-      <div style="margin-top:14px">
+      <div class="spaced-block">
         <button id="cerrar-legal" class="btn btn-outline" type="button" aria-label="Cerrar modal de políticas legales">Cerrar</button>
       </div>
     </div>
@@ -1130,15 +514,15 @@
     </div>
   </div>
   <!-- BANNER MÓVIL -->
-  <div id="mobile-banner" style="display:none;position:fixed;bottom:0;left:0;right:0;background:#003a8c;color:#fff;padding:10px 14px;z-index:9999;display:flex;align-items:center;justify-content:space-between;gap:10px;">
-    <span style="font-size:.95rem;">¿Quieres que revisemos tu factura?</span>
-    <a href="/whatsapp.html" class="btn btn-primary" style="margin:0;padding:8px 14px;font-size:.95rem;" aria-label="Enviar factura por WhatsApp">Solicitar revisión</a>
-    <button id="close-banner" style="background:none;border:none;color:#fff;font-size:1rem;cursor:pointer;" aria-label="Cerrar banner móvil">Cerrar</button>
+  <div id="mobile-banner" class="mobile-banner">
+    <span>¿Quieres que revisemos tu factura?</span>
+    <a href="/whatsapp.html" class="btn btn-primary mobile-banner-btn" aria-label="Enviar factura por WhatsApp">Solicitar revisión</a>
+    <button id="close-banner" class="mobile-banner-close" aria-label="Cerrar banner móvil">Cerrar</button>
   </div>
   <!-- BOTÓN WHATSAPP -->
   <a class="fab-wa" href="https://wa.me/+34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura%20de%20luz%2C%20gas%20o%20tel%C3%A9fono.%20%C2%BFC%C3%B3mo%20empiezo%3F" aria-label="Contactar por WhatsApp para revisar factura" rel="noopener">WhatsApp</a>
   <noscript>
-    <div style="background:#fee2e2;color:#7f1d1d;padding:12px;text-align:center;">
+    <div class="alert-banner">
       Este sitio usa funcionalidades JavaScript (formulario, menú, acordeón y guías). Actívalo para una experiencia completa.
     </div>
   </noscript>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,960 @@
+html { scroll-behavior: smooth; }
+
+:root {
+  --bg: #ffffff;
+  --bg2: #ffffff;
+  --card: #ffffff;
+  --text: #1e1e1e;
+  --muted: #666666;
+  --accent: #22c55e;
+  --link: #666666;
+  --border: #e5e7eb;
+  --shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  --ok: #22c55e;
+  --pill-bg: #f5f5f5;
+  --pill-border: #e5e7eb;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  color: var(--text);
+  line-height: 1.7;
+  font-size: 18px;
+  background: #ffffff;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-family: 'Montserrat', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  color: #111111;
+  margin-bottom: 24px;
+}
+
+h1 {
+  font-size: clamp(28px, 5vw, 44px);
+}
+
+h2 {
+  font-size: clamp(22px, 3.6vw, 32px);
+}
+
+h3 {
+  font-size: clamp(18px, 3vw, 24px);
+}
+
+p {
+  margin-bottom: 12px;
+}
+
+p + p {
+  margin-top: 12px;
+}
+
+a {
+  color: var(--link);
+}
+
+header,
+main,
+footer {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+main section {
+  padding: 80px 20px;
+  background: transparent;
+}
+
+main section + section {
+  margin-top: 60px;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.skip-link {
+  background: var(--accent);
+  color: #ffffff;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 1rem;
+  text-decoration: none;
+  display: block;
+  width: max-content;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 1000;
+}
+
+.skip-link:focus {
+  outline: 2px solid #ffffff;
+}
+.site-header {
+  grid-area: header;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 18px;
+  position: sticky;
+  top: 0;
+  background: #ffffff;
+  z-index: 999;
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+  border-radius: 0 0 12px 12px;
+}
+
+.logo {
+  font-weight: 800;
+  font-size: 1.45rem;
+  color: var(--text);
+  text-decoration: none;
+  letter-spacing: 0.2px;
+}
+
+.nav {
+  grid-area: nav;
+  display: flex;
+  align-items: center;
+}
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 16px;
+}
+
+.nav-links a {
+  color: var(--text);
+  font-weight: 600;
+  text-decoration: none;
+  font-size: 0.95rem;
+  padding: 8px 10px;
+  border-radius: 10px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-links a:hover {
+  background: var(--pill-bg);
+  border: 1px solid var(--pill-border);
+  color: #111111;
+}
+.nav-toggle {
+  display: none;
+  background: none;
+  border: 0;
+  cursor: pointer;
+}
+
+.nav-toggle-bar {
+  display: block;
+  width: 24px;
+  height: 2px;
+  margin: 5px 0;
+  background: var(--text);
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.header-contact {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.header-contact a {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+@media (max-width: 768px) {
+  .nav-toggle {
+    display: block;
+  }
+
+  .nav {
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: 70px;
+    background: #ffffff;
+    transform: translateY(-120%);
+    transition: transform 0.25s ease;
+    height: calc(100vh - 70px);
+    overflow-y: auto;
+    border-top: 1px solid var(--border);
+  }
+
+  .nav.open {
+    transform: translateY(0);
+  }
+
+  .nav-links {
+    flex-direction: column;
+    padding: 10px;
+    gap: 6px;
+  }
+
+  .nav-links li {
+    border-top: 1px solid var(--border);
+  }
+
+  .nav-links a {
+    padding: 12px 14px;
+    display: block;
+  }
+
+  .header-contact {
+    display: none;
+  }
+}
+.hero {
+  text-align: center;
+  padding: 80px 20px;
+}
+
+.wrap {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.grid.grid-2 {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.section-centered,
+#casos,
+#reseñas,
+#guias,
+#que-hacemos {
+  text-align: center;
+}
+
+.hero p {
+  color: var(--text);
+  max-width: 920px;
+  margin: 0 auto 16px;
+  font-size: 1.08rem;
+}
+
+.trustline {
+  margin-top: 0.25rem;
+  color: #111111;
+  font-weight: 700;
+}
+
+.hero .trustline,
+.hero p:first-of-type {
+  background: var(--pill-bg);
+  border: 1px solid var(--pill-border);
+  border-radius: 14px;
+  padding: 12px 14px;
+}
+
+.btn {
+  display: inline-block;
+  padding: 12px 28px;
+  border-radius: 12px;
+  font-weight: 700;
+  text-decoration: none;
+  margin: 8px;
+  font-size: 1rem;
+  letter-spacing: 0.2px;
+  box-shadow: var(--shadow);
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
+  min-height: 44px;
+}
+
+.cta-group {
+  text-align: center;
+  margin-top: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+
+.spaced-block {
+  margin-top: 24px;
+}
+
+.alert-banner {
+  background: #fef2f2;
+  color: #7f1d1d;
+  padding: 12px;
+  text-align: center;
+  border-radius: 12px;
+  border: 1px solid #fecaca;
+  margin-top: 24px;
+}
+
+.mobile-banner {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #22c55e;
+  color: #ffffff;
+  padding: 12px 16px;
+  z-index: 9999;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mobile-banner.is-visible {
+  display: flex;
+}
+
+.mobile-banner span {
+  font-size: 0.95rem;
+}
+
+.mobile-banner-btn {
+  margin: 0;
+  padding: 8px 16px;
+  font-size: 0.95rem;
+}
+
+.mobile-banner-close {
+  background: none;
+  border: none;
+  color: #ffffff;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn-primary {
+  background: var(--ok);
+  color: #ffffff;
+  border: 1px solid var(--ok);
+}
+
+.btn-primary:hover,
+.btn-whatsapp:hover {
+  background: #16a34a;
+}
+
+.btn-outline {
+  border: 1px solid var(--link);
+  color: var(--link);
+  background: #ffffff;
+}
+
+.btn-outline:hover {
+  background: var(--pill-bg);
+  color: #111111;
+}
+
+.btn-whatsapp {
+  background: var(--ok);
+  color: #052e16;
+  border: 1px solid var(--ok);
+}
+
+.media-hero img,
+.media-grid img,
+.casos-media img {
+  width: 100%;
+  height: auto;
+  max-height: 240px;
+  object-fit: contain;
+  object-position: center;
+  border-radius: 14px;
+  box-shadow: var(--shadow);
+  background: #ffffff;
+  padding: 6px;
+  border: 1px solid var(--border);
+}
+
+@media (min-width: 900px) {
+  .media-hero img {
+    max-height: 420px;
+  }
+}
+
+@media (max-width: 600px) {
+  .hero p {
+    background: #ffffff;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+  }
+
+  .hero .btn {
+    width: 100%;
+    max-width: 340px;
+  }
+}
+
+.steps {
+  display: grid;
+  gap: 24px;
+  margin: 24px auto 0;
+  max-width: 920px;
+}
+
+@media (min-width: 900px) {
+  .steps {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.step {
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+  text-align: left;
+  box-shadow: var(--shadow);
+}
+
+.step b {
+  display: block;
+  font-family: 'Montserrat';
+  font-size: 1.05rem;
+  margin-bottom: 8px;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 16px;
+  color: var(--text);
+  font-weight: 700;
+  cursor: pointer;
+  font-size: 1.05rem;
+}
+
+.toggle + .toggle-wrap {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.25s ease;
+}
+
+.toggle-wrap .inner {
+  padding: 12px 2px;
+}
+
+.services {
+  display: grid;
+  gap: 20px;
+}
+
+@media (min-width: 900px) {
+  .services {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.svc {
+  background: #ffffff;
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+}
+
+.svc h3 {
+  margin: 0 0 0.5rem;
+  font-family: 'Montserrat';
+}
+
+.help {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.modal-note {
+  margin: 0.25rem 0 0.5rem;
+}
+
+.highlight-note {
+  background: #f8fafc;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px 18px;
+  margin-top: 24px;
+  color: var(--text);
+}
+
+.card {
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: var(--shadow);
+}
+
+.precio-unico {
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  padding: 40px;
+  max-width: 720px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.precio-unico p {
+  font-size: 1.05rem;
+}
+
+.precio-unico p strong {
+  color: #111111;
+}
+
+.precio-unico ul {
+  list-style: none;
+  margin: 24px auto;
+  padding: 0;
+  max-width: 540px;
+  text-align: left;
+}
+
+.precio-unico ul li {
+  position: relative;
+  padding-left: 1.5rem;
+  margin-bottom: 16px;
+}
+
+.precio-unico ul li::before {
+  content: '•';
+  position: absolute;
+  left: 0;
+  color: #16a34a;
+}
+
+.precio-unico + .help {
+  margin-top: 32px;
+}
+
+.trust-badges {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 8px;
+  opacity: 0.9;
+  flex-wrap: wrap;
+}
+
+.trust-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 0.9rem;
+  color: var(--text);
+  background: #ffffff;
+}
+
+.testimonials {
+  display: grid;
+  gap: 24px;
+  margin-top: 24px;
+}
+
+@media (min-width: 900px) {
+  .testimonials {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.case-card {
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+
+.case-card h3 {
+  font-size: 1.05rem;
+  margin-bottom: 8px;
+}
+
+.case-meta {
+  font-size: 0.92rem;
+  color: var(--muted);
+  margin: 0.25rem 0 0.75rem;
+}
+
+.legal-note {
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin-top: 8px;
+}
+
+#confianza {
+  padding: 40px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: var(--shadow);
+}
+
+#guias {
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  padding: 40px 20px;
+}
+
+#confianza ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#confianza ul li {
+  position: relative;
+  padding-left: 1.5rem;
+  margin-bottom: 12px;
+}
+
+#confianza ul li::before {
+  content: '•';
+  position: absolute;
+  left: 0;
+  color: #16a34a;
+}
+
+#reclamoForm input,
+#reclamoForm textarea {
+  width: 100%;
+  margin: 10px 0;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #ffffff;
+  color: var(--text);
+  font-size: 1rem;
+}
+
+#reclamoForm textarea {
+  min-height: 160px;
+  resize: vertical;
+}
+
+#reclamoForm label {
+  display: block;
+  margin: 8px 0;
+  font-weight: 600;
+}
+
+#formOK {
+  color: #16a34a;
+  display: none;
+}
+
+#formERR {
+  color: #b91c1c;
+  display: none;
+}
+
+.footer {
+  grid-area: footer;
+  border-top: 1px solid var(--border);
+  margin-top: 60px;
+  padding: 60px 20px 90px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.footer a {
+  color: var(--link);
+}
+
+#legal-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 9999;
+}
+
+.modal-wrap {
+  background: #ffffff;
+  color: var(--text);
+  width: min(900px, 92vw);
+  max-height: 90vh;
+  border-radius: 12px;
+  overflow-y: auto;
+  padding: 24px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.modal-toplinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 8px 0 14px;
+}
+
+.chip {
+  border: 1px solid var(--border);
+  padding: 6px 12px;
+  border-radius: 999px;
+  text-decoration: none;
+  color: var(--text);
+  font-size: 0.95rem;
+  background: #ffffff;
+}
+
+.fab-wa {
+  position: fixed;
+  right: 16px;
+  bottom: 80px;
+  z-index: 1000;
+  background: #22c55e;
+  color: #052e16;
+  font-weight: 800;
+  border-radius: 999px;
+  padding: 12px 18px;
+  text-decoration: none;
+  font-size: 1rem;
+  border: 1px solid #16a34a;
+  box-shadow: var(--shadow);
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 600px) {
+  .fab-wa {
+    bottom: 80px;
+    padding: 10px 16px;
+    font-size: 0.95rem;
+  }
+}
+
+.media-grid,
+.casos-media {
+  display: grid;
+  gap: 16px;
+  align-items: start;
+  justify-items: center;
+}
+
+.media-grid img,
+.casos-media img {
+  max-width: 640px;
+}
+
+@media (max-width: 700px) {
+  .media-grid,
+  .casos-media {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 700px) {
+  .media-grid,
+  .casos-media {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.payment-lock {
+  display: block;
+  margin: 14px auto 0;
+  width: 120px;
+  height: auto;
+  object-fit: contain;
+  opacity: 0.95;
+}
+
+.banner-lock {
+  padding: 40px 0;
+}
+
+.exit-popup {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 10000;
+  align-items: center;
+  justify-content: center;
+}
+
+.exit-popup-content {
+  background: #ffffff;
+  padding: 24px;
+  border-radius: 12px;
+  text-align: center;
+  max-width: 400px;
+  box-shadow: var(--shadow);
+}
+
+.exit-popup-content h2 {
+  font-size: 1.5rem;
+  margin-bottom: 10px;
+}
+
+.exit-popup-content p {
+  font-size: 1rem;
+  color: var(--muted);
+  margin-bottom: 14px;
+}
+
+.faq-section {
+  margin-top: 24px;
+}
+
+.faq-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 16px;
+  color: var(--text);
+  font-weight: 700;
+  cursor: pointer;
+  font-size: 1.05rem;
+}
+
+.faq-toggle + .faq-wrap {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.25s ease;
+}
+
+.faq-wrap .inner {
+  padding: 16px 4px;
+}
+
+#reseñas .btn {
+  margin: 6px;
+}
+
+.free-study {
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 40px;
+  margin: 40px 0;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.free-study .btn {
+  margin-top: 24px;
+}
+
+@media (max-width: 768px) {
+  body {
+    line-height: 1.6;
+  }
+
+  header,
+  main,
+  footer {
+    padding: 16px;
+  }
+
+  main section {
+    padding: 60px 16px;
+  }
+
+  section p {
+    max-width: 90%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .btn {
+    width: 100%;
+    max-width: 320px;
+    margin: 12px auto 24px;
+  }
+
+  .steps {
+    gap: 20px;
+  }
+
+  main li {
+    margin-bottom: 20px;
+  }
+
+  #precios,
+  #estudio-gratis,
+  #casos,
+  #reseñas,
+  #confianza,
+  #guias,
+  .precio-unico {
+    text-align: center;
+  }
+
+  .cta-group {
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .precio-unico {
+    padding: 32px 20px;
+  }
+
+  .precio-unico ul {
+    max-width: 100%;
+  }
+
+  #confianza {
+    padding: 32px 20px;
+  }
+}


### PR DESCRIPTION
## Summary
- move the inline styles into a dedicated style.css and refresh the palette with white backgrounds, dark typography, and green accents
- update the hero, testimonials, and pricing copy to emphasise a single price point with refreshed CTA text and spacing
- refine responsive behaviour for sections, CTA groups, and the mobile banner while keeping metadata up to date

## Testing
- Not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f1bbde5f08320a60b9fe3ca9aac31)