### PR TITLE
Refresh landing page structure and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,21 +12,21 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Reclamación de facturas de luz y gas – TuReclamoExprés</title>
-  <meta name="description" content="Revisamos gratis tu factura y reclamamos los cobros indebidos por ti. Gestión completa desde 39,99 €, fondo blanco profesional y resultado en 24–48 h." />
-  <meta name="keywords" content="reclamación de factura eléctrica y gas, reclamar factura de luz, reclamar factura de gas, cobros indebidos, estudio energético certificado" />
+  <meta name="description" content="Analizamos tu factura, detectamos cobros indebidos y te mostramos cómo ahorrar en tu tarifa de luz o gas. Revisión gratuita, sin compromiso y resultado en 24–48 h." />
+  <meta name="keywords" content="reclamación de factura eléctrica y gas, reclamar factura de luz, reclamar factura de gas, cobros indebidos, comparación de tarifas" />
   <meta name="robots" content="index,follow" />
   <meta name="theme-color" content="#ffffff" />
   <link rel="canonical" href="https://tureclamoexpres.com/" />
   <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
   <!-- Open Graph / Twitter -->
   <meta property="og:title" content="Reclamación de facturas de luz y gas – TuReclamoExprés" />
-  <meta property="og:description" content="Revisamos gratis tu factura y reclamamos los cobros indebidos por ti. Gestión completa desde 39,99 € y resultado en 24–48 h." />
+  <meta property="og:description" content="Analizamos tu factura, detectamos cobros indebidos y te mostramos cómo ahorrar en tu tarifa de luz o gas. Revisión gratuita, sin compromiso y resultado en 24–48 h." />
   <meta property="og:image" content="https://tureclamoexpres.com/og-image.jpg" />
   <meta property="og:url" content="https://tureclamoexpres.com" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Reclamación de facturas de luz y gas – TuReclamoExprés" />
-  <meta name="twitter:description" content="Revisamos gratis tu factura y reclamamos los cobros indebidos por ti. Gestión completa desde 39,99 € y resultado en 24–48 h." />
+  <meta name="twitter:description" content="Analizamos tu factura, detectamos cobros indebidos y te mostramos cómo ahorrar en tu tarifa de luz o gas. Revisión gratuita, sin compromiso y resultado en 24–48 h." />
   <meta name="twitter:image" content="https://tureclamoexpres.com/og-image.jpg" />
   <link rel="icon" href="/favicon.ico" />
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
@@ -42,7 +42,7 @@
     "@context": "https://schema.org",
     "@type": "Service",
     "name": "TuReclamoExprés - Revisión y Gestión de Reclamaciones",
-    "description": "Revisión gratuita de facturas de luz, gas, telefonía y más para detectar cobros indebidos. Reclamación por 39,99€. Estudio energético GRATIS con colaboradores.",
+    "description": "Revisión gratuita de facturas de luz, gas, telefonía y más para detectar cobros indebidos y comparar tarifas. Reclamación por 39,99 € solo si decides continuar.",
     "provider": {
       "@type": "Organization",
       "name": "S.A.G. Servicios Digitales",
@@ -197,25 +197,72 @@
     <!-- HERO -->
     <section class="hero" id="inicio">
       <div class="hero-logo">
-        <img src="logo.jfif" alt="TuReclamoExprés" width="180" height="auto" />
+        <img src="logo-principal.jpg" alt="TuReclamoExprés" width="200" height="200" />
       </div>
-      <h1>Reclama los cobros indebidos de tu factura de luz o gas</h1>
-      <p class="trustline">Revisamos tu factura y comprobamos si existen errores o importes indebidos. Incluye un <strong>estudio energético certificado gratuito</strong> con tu análisis.</p>
-      <p><strong>Precio único de 39,99 € IVA incluido</strong> cuando decides reclamar. Seguimiento completo y resultado en 24–48 h.</p>
-      <p>Sin compromiso, sin letra pequeña y con informe certificado en cada revisión.</p>
+      <h1>Reclama y ahorra en tu factura de luz o gas</h1>
+      <p class="hero-subtitle">Comprobamos si pagas de más y te conseguimos la mejor tarifa sin compromiso.</p>
+      <div class="hero-actions">
+        <a class="btn btn-primary" href="#revision" aria-label="Comparar mi factura y ver ahorro" aria-describedby="cta-desc">Comparar mi factura y ver ahorro</a>
+      </div>
+      <p id="cta-desc" class="sr-only">Compararemos tu factura gratis y te mostraremos el ahorro disponible en 24–48 h.</p>
+      <p class="hero-note">Revisión gratuita con resultado en 24–48 h.</p>
       <figure class="media-hero" aria-label="Ilustración revisión de factura">
-        <img loading="lazy" decoding="async" width="640" height="360" src="hero-mujer-factura.jpg" alt="Mujer revisando una factura de luz con alivio tras recuperar dinero">
+        <img loading="lazy" decoding="async" width="640" height="360" src="hero-mujer-factura.jpg" alt="Mujer revisando una factura de luz y feliz tras reducir su pago mensual">
       </figure>
-      <div>
-        <a class="btn btn-primary" href="#revision" aria-label="Solicitar revisión gratuita de factura" aria-describedby="cta-desc">Revisión gratuita de factura</a>
-        <a class="btn btn-outline" href="#precios" aria-label="Consultar el precio único del servicio" aria-describedby="cta-desc">Ver precio único</a>
+    </section>
+    <!-- BLOQUE DE PRUEBA SOCIAL -->
+    <section class="social-proof" aria-label="Resultados de clientes">
+      <p>Más de 5.000 facturas revisadas · 250.000 € recuperados · Valoración media 4,8⭐</p>
+      <a class="btn btn-outline" href="https://g.page/r/CYf0jfou4O_XEAE/review" target="_blank" rel="noopener" aria-label="Ver reseñas en Google">Ver reseñas en Google</a>
+    </section>
+    <!-- QUÉ HACEMOS -->
+    <section id="que-hacemos" aria-label="Qué hacemos por ti">
+      <h2>Qué hacemos por ti</h2>
+      <p>Analizamos tu factura, detectamos cobros indebidos y te ayudamos a reclamar lo que es tuyo.</p>
+      <p>Además, te mostramos la mejor tarifa actual del mercado para que empieces a ahorrar desde la próxima factura.</p>
+      <div class="media-grid" aria-label="Equipo revisando casos">
+        <img loading="lazy" decoding="async" width="640" height="360" src="persona-hombre-pc.jpg" alt="Asesor digital revisando una factura para reclamar cobros indebidos">
       </div>
-      <p id="cta-desc" class="sr-only">Inicia la revisión gratuita de tu factura o consulta nuestro precio único para la gestión completa.</p>
-      <p class="help highlight-note">Respuesta profesional en 24–48 h, tratamiento confidencial de datos y pago seguro cuando el servicio lo requiera.</p>
-      <div class="trust-badges" aria-label="Reseñas y estadísticas de confianza">
-        <span class="trust-badge">Más de 5.000 facturas analizadas</span>
-        <span class="trust-badge">Más de 250.000 € recuperados</span>
-        <span class="trust-badge">Valoración media 4,8/5 en Google</span>
+      <button class="faq-toggle" id="toggleServicios" aria-expanded="false" aria-controls="serviciosWrap" aria-label="Mostrar u ocultar servicios">
+        <span>Ver servicios</span><span aria-hidden="true">⌄</span>
+      </button>
+      <div id="serviciosWrap" class="faq-wrap" role="region" aria-label="Listado de servicios">
+        <div class="inner">
+          <div class="services">
+            <div class="svc">
+              <h3>Revisión inicial de facturas (sin coste)</h3>
+              <p class="help">Analizamos luz, gas y telefonía. Detectamos abusos, duplicados o cargos no solicitados e indicamos si hay importe recuperable.</p>
+            </div>
+            <div class="svc">
+              <h3>Reclamaciones por cobros indebidos</h3>
+              <p class="help">Preparamos tu reclamación personalizada con base legal. Si delegas la gestión completa, la enviamos por ti, hacemos seguimiento y te confirmamos el acuse.</p>
+            </div>
+            <div class="svc">
+              <h3>Telefonía e Internet</h3>
+              <p class="help">Penalizaciones, subidas no informadas, permanencias abusivas y cargos de terceros (SMS premium, etc.).</p>
+            </div>
+            <div class="svc">
+              <h3>Energía (luz y gas)</h3>
+              <p class="help">Revisión de potencia, peajes, ajustes y estimaciones incorrectas. Cuantificamos errores y reclamamos importes.</p>
+            </div>
+            <div class="svc">
+              <h3>Bajas complicadas y altas no consentidas</h3>
+              <p class="help">Si te ponen trabas para la baja o te han dado de alta sin consentimiento, reclamamos y cortamos continuidad.</p>
+            </div>
+            <div class="svc">
+              <h3>Seguimiento integral</h3>
+              <p class="help">Delegas todo: envío, respuestas, réplicas y recordatorios a la entidad hasta cierre del caso.</p>
+            </div>
+            <div class="svc">
+              <h3>Soporte legal externo (si procede)</h3>
+              <p class="help">Si el caso requiere abogado, derivamos —con tu consentimiento— a colaboradores colegiados (ellos gestionan sus honorarios).</p>
+            </div>
+          </div>
+          <div class="cta-group">
+            <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión por WhatsApp</a>
+            <a class="btn btn-outline" href="#formulario" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
+          </div>
+        </div>
       </div>
     </section>
     <!-- CÓMO FUNCIONA -->
@@ -223,18 +270,28 @@
       <h2>Cómo funciona</h2>
       <div class="steps" aria-label="Proceso en 3 pasos">
         <div class="step">
-          <b>1. Envíanos tu factura</b>
-          Sube la documentación por WhatsApp o correo electrónico para iniciar la revisión sin coste.
+          <b>1. Súbenos tu factura</b>
+          Súbenos tu factura por WhatsApp o email.
         </div>
         <div class="step">
-          <b>2. Verificamos cobros y condiciones</b>
-          En 24–48 h confirmamos si existen cobros indebidos y te entregamos el informe energético certificado.
+          <b>2. Confirmamos si pagas de más</b>
+          En 24–48 h te confirmamos si pagas de más.
         </div>
         <div class="step">
-          <b>3. Decide los siguientes pasos</b>
-          Si lo deseas, preparamos y gestionamos la reclamación completa con nuestro servicio de precio cerrado.
+          <b>3. Elige cómo ahorrar</b>
+          Decide: reclamamos por ti o te mostramos la tarifa más barata.
         </div>
       </div>
+      <div class="steps-cta">
+        <a class="btn btn-primary" href="#revision" aria-label="Comparar mi factura y ahorrar ahora">Comparar mi factura y ahorrar ahora</a>
+      </div>
+    </section>
+    <!-- ANÁLISIS DE AHORRO -->
+    <section class="analisis-ahorro" aria-label="Análisis de ahorro y comparación de tarifas">
+      <h2>Análisis de ahorro y comparación de tarifas</h2>
+      <p>Analizamos tu factura y te mostramos si estás pagando de más. Comparamos tus condiciones actuales con las mejores ofertas del mercado y te indicamos cuánto podrías ahorrar cada mes.</p>
+      <p>Incluye revisión gratuita, sin compromiso, y con resultado en 24–48 h.</p>
+      <a href="#revision" class="btn btn-primary">Comparar mi factura y ver ahorro</a>
     </section>
     <!-- CASOS REALES -->
     <section id="casos">
@@ -284,12 +341,7 @@
       <section class="precio-unico">
         <h2>Gestión completa de reclamación</h2>
         <p><strong>39,99 € IVA incluido</strong></p>
-        <p>Revisión gratuita e informe certificado. Si detectamos cobros indebidos y decides reclamar, gestionamos todo el proceso por ti hasta la resolución final.</p>
-        <ul>
-          <li>Reclamación completa en tu nombre</li>
-          <li>Seguimiento telemático y comunicación continua</li>
-          <li>Resultado en 24–48 h</li>
-        </ul>
+        <p>Revisión gratuita + reclamación completa solo si decides reclamar.</p>
         <a href="#revision" class="btn btn-primary">Iniciar revisión gratuita</a>
       </section>
       <p class="help">Tu devolución se abona siempre directamente por tu compañía en tu cuenta o factura; nosotros únicamente gestionamos el expediente.</p>
@@ -324,7 +376,7 @@
     <!-- FORMULARIO -->
     <section id="formulario">
       <h2>Contacto y formulario</h2>
-      <p class="help">Cuéntanos tu caso y adjunta tu recibo. Revisamos gratis la reclamación de factura eléctrica y gas y te confirmamos el siguiente paso en 24–48 h.</p>
+      <p class="help">Cuéntanos tu caso y adjunta tu recibo. Revisamos gratis tu factura de luz o gas, te confirmamos si pagas de más y te mostramos el ahorro disponible en 24–48 h.</p>
       <form id="reclamoForm" action="https://formspree.io/f/mzzvnwll" method="POST" novalidate>
         <label for="nombre">Nombre completo</label>
         <input type="text" id="nombre" name="nombre" placeholder="Nombre completo" required autocomplete="name" />
@@ -342,54 +394,6 @@
         <p id="formOK" aria-live="polite">Envío realizado correctamente</p>
         <p id="formERR" aria-live="assertive">Se produjo un error al enviar</p>
       </form>
-    </section>
-    <!-- QUÉ HACEMOS -->
-    <section id="que-hacemos">
-      <h2>Qué hacemos por ti</h2>
-      <div class="media-grid" aria-label="Equipo revisando casos">
-        <img loading="lazy" decoding="async" width="640" height="360" src="persona-hombre-pc.jpg" alt="Asesor digital preparando una reclamación para recuperar dinero">
-      </div>
-      <button class="faq-toggle" id="toggleServicios" aria-expanded="false" aria-controls="serviciosWrap" aria-label="Mostrar u ocultar servicios">
-        <span>Ver servicios</span><span aria-hidden="true">⌄</span>
-      </button>
-      <div id="serviciosWrap" class="faq-wrap" role="region" aria-label="Listado de servicios">
-        <div class="inner">
-          <div class="services">
-            <div class="svc">
-              <h3>Revisión inicial de facturas (sin coste)</h3>
-              <p class="help">Analizamos luz, gas y telefonía. Detectamos abusos, duplicados o cargos no solicitados e indicamos si hay importe recuperable.</p>
-            </div>
-            <div class="svc">
-              <h3>Reclamaciones por cobros indebidos</h3>
-              <p class="help">Preparamos tu reclamación personalizada con base legal. Si delegas la gestión completa, la enviamos por ti, hacemos seguimiento y te confirmamos el acuse.</p>
-            </div>
-            <div class="svc">
-              <h3>Telefonía e Internet</h3>
-              <p class="help">Penalizaciones, subidas no informadas, permanencias abusivas y cargos de terceros (SMS premium, etc.).</p>
-            </div>
-            <div class="svc">
-              <h3>Energía (luz y gas)</h3>
-              <p class="help">Revisión de potencia, peajes, ajustes y estimaciones incorrectas. Cuantificamos errores y reclamamos importes.</p>
-            </div>
-            <div class="svc">
-              <h3>Bajas complicadas y altas no consentidas</h3>
-              <p class="help">Si te ponen trabas para la baja o te han dado de alta sin consentimiento, reclamamos y cortamos continuidad.</p>
-            </div>
-            <div class="svc">
-              <h3>Seguimiento integral</h3>
-              <p class="help">Delegas todo: envío, respuestas, réplicas y recordatorios a la entidad hasta cierre del caso.</p>
-            </div>
-            <div class="svc">
-              <h3>Soporte legal externo (si procede)</h3>
-              <p class="help">Si el caso requiere abogado, derivamos —con tu consentimiento— a colaboradores colegiados (ellos gestionan sus honorarios).</p>
-            </div>
-          </div>
-          <div class="cta-group">
-            <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión por WhatsApp</a>
-            <a class="btn btn-outline" href="#formulario" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
-          </div>
-        </div>
-      </div>
     </section>
     <!-- GUÍAS -->
     <section id="guias">
@@ -430,13 +434,6 @@
         </div>
       </div>
     </section>
-    <!-- ESTUDIO ENERGÉTICO -->
-    <section id="estudio-gratis" class="free-study">
-      <h2>Estudio energético certificado sin coste</h2>
-      <p>Calculamos tu consumo real, contrastamos tarifas vigentes y proponemos ajustes para reducir la factura. El informe es gratuito y solo realizamos reclamaciones adicionales si lo solicitas.</p>
-      <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20me%20gustar%C3%ADa%20solicitar%20un%20estudio%20energ%C3%A9tico%20gratuito" target="_blank" rel="noopener">
-        Solicitar estudio por WhatsApp</a>
-    </section>
     <!-- BANNER: solo candado -->
     <section class="banner-lock" aria-label="Seguridad">
       <img class="payment-lock" loading="lazy" decoding="async" width="120" height="80" src="logo-seguridad-pago.jpg" alt="Ícono de pago seguro con Stripe, Visa y Mastercard">
@@ -445,10 +442,10 @@
     <section id="confianza" class="confianza">
       <h2>Por qué confiar en TuReclamoExprés</h2>
       <ul>
-        <li><strong>Incluye estudio energético certificado</strong> realizado por nuestro equipo especializado.</li>
+        <li><strong>Revisión gratuita y análisis de ahorro</strong> realizado por nuestro equipo especializado.</li>
         <li><strong>Especialistas</strong> en luz, gas y telecomunicaciones.</li>
         <li><strong>Precios cerrados</strong> y comunicación transparente desde el inicio.</li>
-        <li><strong>Revisión inicial</strong> en 24–48 h con informe detallado.</li>
+        <li><strong>Diagnóstico inicial</strong> en 24–48 h con detalle de cobros indebidos y mejores tarifas.</li>
         <li><strong>Datos protegidos (RGPD)</strong> y <strong>pago seguro</strong> con Stripe, Visa y Mastercard.</li>
         <li><strong>Atención al cliente</strong>: <a href="tel:+34953818494" aria-label="Llamar al 953 818 494">953 818 494</a> · <a href="mailto:info@tureclamoexpres.com" aria-label="Enviar email a info@tureclamoexpres.com">info@tureclamoexpres.com</a></li>
         <li><strong>Tu devolución se abona directamente</strong> por tu compañía en tu cuenta o factura.</li>
@@ -459,7 +456,7 @@
         <span class="trust-badge">Más de 250.000 € recuperados</span>
       </div>
       <div class="cta-group">
-        <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar estudio energético certificado" rel="noopener" aria-describedby="cta-desc">Solicitar estudio energético</a>
+        <a class="btn btn-primary" href="/whatsapp.html" aria-label="Comparar mi factura por WhatsApp" rel="noopener" aria-describedby="cta-desc">Comparar mi factura por WhatsApp</a>
         <a class="btn btn-outline" href="#formulario" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
         <a class="btn btn-primary" href="https://g.page/r/CYf0jfou4O_XEAE/review" target="_blank" rel="noopener" aria-label="Consultar reseñas en Google" aria-describedby="cta-desc">Consultar reseñas en Google</a>
       </div>
@@ -473,7 +470,7 @@
     
   </main>
   <footer class="footer" role="contentinfo">
-    <img src="logo.jfif" alt="TuReclamoExprés" class="footer-logo" />
+    <img src="logo-principal.jpg" alt="TuReclamoExprés" class="footer-logo" />
     <p>© <span id="year"></span> TuReclamoExprés · <a href="#como-funciona">Cómo funciona</a> · <a href="#precios">Precios</a> · <a href="#guias">Guías</a> · <a href="#formulario">Enviar factura</a> · <a href="/whatsapp.html">WhatsApp</a></p>
     <p><a href="tel:+34953818494" aria-label="Llamar al 953 818 494">953 818 494</a> · <a href="mailto:info@tureclamoexpres.com" aria-label="Enviar email a info@tureclamoexpres.com">info@tureclamoexpres.com</a></p>
   </footer>

--- a/style.css
+++ b/style.css
@@ -34,7 +34,7 @@ h2,
 h3,
 h4 {
   font-family: 'Montserrat', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-  color: #111827;
+  color: #0b2f6b;
   margin-bottom: 24px;
 }
 
@@ -261,21 +261,26 @@ main section + section {
     right: 20px;
   }
 }
+
 .hero {
   text-align: center;
-  padding: 60px 20px;
+  padding: 80px 20px 60px;
+  background-color: #ffffff;
+  border-radius: 24px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 2px 12px rgba(11, 47, 107, 0.08);
 }
 
 .hero-logo img {
   display: block;
-  margin: 0 auto 16px auto;
-  width: 180px;
+  margin: 0 auto 24px auto;
+  width: 200px;
   max-width: 100%;
 }
 
 @media (max-width: 768px) {
   .hero-logo img {
-    width: 140px;
+    width: 160px;
   }
 }
 
@@ -298,25 +303,45 @@ main section + section {
   text-align: center;
 }
 
+#que-hacemos {
+  background-color: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 20px;
+  box-shadow: 0 2px 12px rgba(11, 47, 107, 0.06);
+}
+
+#que-hacemos .faq-toggle {
+  margin: 32px auto 0;
+  max-width: 720px;
+}
+
+#que-hacemos .faq-wrap .inner {
+  padding: 20px 4px;
+}
+
 .hero p {
   color: var(--text);
-  max-width: 920px;
-  margin: 0 auto 16px;
+  max-width: 760px;
+  margin: 0 auto 18px;
   font-size: 1.08rem;
 }
 
-.trustline {
-  margin-top: 0.25rem;
-  color: #111111;
-  font-weight: 700;
+.hero-subtitle {
+  font-size: clamp(1.1rem, 2.2vw, 1.4rem);
+  color: #1e1e1e;
 }
 
-.hero .trustline,
-.hero p:first-of-type {
-  background: var(--pill-bg);
-  border: 1px solid var(--pill-border);
-  border-radius: 14px;
-  padding: 12px 14px;
+.hero-actions {
+  margin: 24px 0 16px;
+}
+
+.hero-note {
+  color: #4b5563;
+  font-weight: 500;
+}
+
+.media-hero {
+  margin-top: 32px;
 }
 
 .btn {
@@ -447,6 +472,27 @@ main section + section {
   }
 }
 
+.social-proof {
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  padding: 32px 20px;
+  text-align: center;
+  margin: 40px auto 0;
+  max-width: 840px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.social-proof p {
+  font-weight: 600;
+  color: #1e1e1e;
+  margin-bottom: 16px;
+}
+
+.social-proof .btn {
+  margin: 0;
+}
+
 @media (max-width: 600px) {
   .hero p {
     background: #ffffff;
@@ -488,6 +534,48 @@ main section + section {
   font-family: 'Montserrat';
   font-size: 1.05rem;
   margin-bottom: 8px;
+}
+
+.steps-cta {
+  text-align: center;
+  margin-top: 32px;
+}
+
+.steps-cta .btn {
+  margin: 0 auto;
+}
+
+.analisis-ahorro {
+  background-color: #e6f0fa;
+  color: #1e1e1e;
+  border-radius: 14px;
+  padding: 60px 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  text-align: center;
+}
+
+.analisis-ahorro h2 {
+  color: #0b2f6b;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.analisis-ahorro p {
+  max-width: 720px;
+  margin: 0 auto 16px auto;
+  line-height: 1.6;
+}
+
+.analisis-ahorro .btn-primary {
+  background-color: #22c55e;
+  color: #ffffff;
+  padding: 14px 32px;
+  border-radius: 10px;
+  text-decoration: none;
+}
+
+.analisis-ahorro .btn-primary:hover {
+  background-color: #15803d;
 }
 
 .toggle {
@@ -532,6 +620,7 @@ main section + section {
   border: 1px solid var(--border);
   border-radius: 14px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  text-align: left;
 }
 
 .svc h3 {
@@ -566,7 +655,7 @@ main section + section {
 }
 
 .precio-unico {
-  background: #f9fafb;
+  background: #e6f0fa;
   border: 1px solid var(--border);
   border-radius: 14px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
@@ -582,27 +671,6 @@ main section + section {
 
 .precio-unico p strong {
   color: #0b2f6b;
-}
-
-.precio-unico ul {
-  list-style: none;
-  margin: 24px auto;
-  padding: 0;
-  max-width: 540px;
-  text-align: left;
-}
-
-.precio-unico ul li {
-  position: relative;
-  padding-left: 1.5rem;
-  margin-bottom: 16px;
-}
-
-.precio-unico ul li::before {
-  content: '✔';
-  position: absolute;
-  left: 0;
-  color: #22c55e;
 }
 
 .precio-unico + .help {
@@ -754,6 +822,15 @@ main section + section {
   display: block;
   margin: 8px 0;
   font-weight: 600;
+}
+
+#formulario form {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 32px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  margin-top: 24px;
 }
 
 #formOK {
@@ -939,12 +1016,16 @@ body.dark-mode .btn-outline:hover {
   color: #22c55e;
 }
 
+body.dark-mode #formulario form {
+  background-color: #10213d;
+  border-color: #1e3a8a;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.6);
+}
+
 body.dark-mode .card,
 body.dark-mode .step,
 body.dark-mode .svc,
 body.dark-mode .case-card,
-body.dark-mode .precio-unico,
-body.dark-mode .free-study,
 body.dark-mode .highlight-note,
 body.dark-mode .toggle,
 body.dark-mode .faq-toggle,
@@ -955,10 +1036,51 @@ body.dark-mode .exit-popup-content {
   color: #f9fafb;
 }
 
+body.dark-mode .hero,
+body.dark-mode .social-proof {
+  background-color: #10213d;
+  border-color: #1e3a8a;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.6);
+}
+
+body.dark-mode .social-proof,
+body.dark-mode .social-proof p {
+  color: #ffffff;
+}
+
+body.dark-mode .hero-note,
+body.dark-mode .hero-subtitle {
+  color: #f3f4f6;
+}
+
+body.dark-mode #que-hacemos {
+  background-color: #10213d;
+  border-color: #1e3a8a;
+  color: #ffffff;
+}
+
+body.dark-mode #que-hacemos p {
+  color: #f3f4f6;
+}
+
 body.dark-mode .modal-wrap {
   background: #111827;
   border-color: #374151;
   color: #f9fafb;
+}
+
+body.dark-mode .analisis-ahorro,
+body.dark-mode .precio-unico {
+  background-color: #10213d;
+  border-color: #1e3a8a;
+  color: #ffffff;
+}
+
+body.dark-mode .analisis-ahorro .btn-primary,
+body.dark-mode .precio-unico .btn-primary {
+  background-color: #22c55e;
+  border-color: #22c55e;
+  color: #ffffff;
 }
 
 body.dark-mode .confianza::before {
@@ -967,13 +1089,6 @@ body.dark-mode .confianza::before {
 
 body.dark-mode .trust-badge {
   background: #111827;
-  border-color: #374151;
-  color: #f9fafb;
-}
-
-body.dark-mode .hero .trustline,
-body.dark-mode .hero p:first-of-type {
-  background: #1f2937;
   border-color: #374151;
   color: #f9fafb;
 }
@@ -1120,20 +1235,6 @@ body.dark-mode .exit-popup-content p {
   margin: 6px;
 }
 
-.free-study {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 40px;
-  margin: 40px 0;
-  text-align: center;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-}
-
-.free-study .btn {
-  margin-top: 24px;
-}
-
 @media (max-width: 768px) {
   body {
     line-height: 1.6;
@@ -1169,13 +1270,25 @@ body.dark-mode .exit-popup-content p {
   }
 
   #precios,
-  #estudio-gratis,
   #casos,
   #reseñas,
   #confianza,
   #guias,
-  .precio-unico {
+  .precio-unico,
+  .analisis-ahorro {
     text-align: center;
+  }
+
+  .hero {
+    padding: 60px 16px 48px;
+  }
+
+  .hero-actions {
+    margin-top: 20px;
+  }
+
+  .hero-note {
+    font-size: 0.95rem;
   }
 
   .cta-group {
@@ -1188,8 +1301,12 @@ body.dark-mode .exit-popup-content p {
     padding: 32px 20px;
   }
 
-  .precio-unico ul {
-    max-width: 100%;
+  .analisis-ahorro {
+    padding: 48px 20px;
+  }
+
+  #formulario form {
+    padding: 24px;
   }
 
   #confianza {


### PR DESCRIPTION
## Summary
- Reorganize the homepage hero, social proof, service overview, how it works, analysis, pricing, and contact blocks with the updated copy, CTAs, and corporate assets
- Update meta tags and structured data descriptions to remove references to the old estudio energético messaging and highlight the new offer
- Refresh the CSS palette with the corporate colors, add styles for the new sections, form card, and dark mode adjustments including the logo treatments

## Testing
- Not run (static site)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f305c3e688320aa265fefbe21ef3f)