### PR TITLE
Add configurable timeout to link checker script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ python3 scripts/check_internal_links.py
 
 El script levanta un servidor HTTP temporal en `127.0.0.1` y rastrea todos los archivos HTML generados. Solo valida enlaces internos (rutas relativas o comenzadas por `/`) e ignora dominios externos, enlaces `mailto:` y `tel:`.
 
+Puedes ajustar el tiempo máximo de espera para cada petición con `--timeout`. Por ejemplo, para reducirlo a 5 segundos:
+
+```bash
+python3 scripts/check_internal_links.py --timeout 5
+```
+
 ### Interpretación de resultados
 
 * Cuando no hay incidencias, el comando finaliza con código `0` y muestra:


### PR DESCRIPTION
## Summary
- add a --timeout flag to the internal link checker to prevent hanging requests
- apply the configured timeout to all HTTP calls and guard against non-positive values
- document the new option in the README with an example invocation

## Testing
- python3 -m compileall scripts/check_internal_links.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c34b9d888320a909534cc1b06565)