### PR TITLE
Fix mobile header layout and navigation toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,17 +177,11 @@
   <!-- End Google Tag Manager (noscript) -->
 
   <header class="site-header" role="banner">
-    <a class="logo" href="#inicio" aria-label="TuReclamoExprés - Volver al inicio">TuReclamoExprés</a>
+    <div class="header-left">
+      <a class="logo" href="#inicio" aria-label="TuReclamoExprés - Volver al inicio">TuReclamoExprés</a>
+    </div>
 
-    <button id="theme-toggle" aria-label="Cambiar tema" class="theme-toggle">🌙</button>
-
-    <button class="nav-toggle" aria-controls="primary-nav" aria-expanded="false" aria-label="Abrir menú de navegación">
-      <span class="nav-toggle-bar"></span>
-      <span class="nav-toggle-bar"></span>
-      <span class="nav-toggle-bar"></span>
-    </button>
-
-    <nav id="primary-nav" class="nav" role="navigation" aria-label="Navegación principal">
+    <nav id="primary-nav" class="mobile-menu" role="navigation" aria-label="Navegación principal">
       <ul class="nav-links">
         <li><a href="#como-funciona" aria-current="page">Cómo funciona</a></li>
         <li><a href="#precios">Precios</a></li>
@@ -197,6 +191,16 @@
         <li><a href="#" id="openLegalModalLink">Legales</a></li>
       </ul>
     </nav>
+
+    <div class="header-actions">
+      <button id="theme-toggle" aria-label="Cambiar tema" class="theme-toggle">🌙</button>
+
+      <button class="menu-toggle" aria-controls="primary-nav" aria-expanded="false" aria-label="Abrir menú de navegación">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+    </div>
 
   </header>
   
@@ -542,21 +546,23 @@
       // Año dinámico
       document.getElementById('year').textContent = new Date().getFullYear();
       // Menú móvil
-      const navToggle = document.querySelector('.nav-toggle');
-      const nav = document.getElementById('primary-nav');
-      const navLinks = nav.querySelectorAll('a');
-      navToggle.addEventListener('click', () => {
-        const isOpen = nav.classList.toggle('open');
-        navToggle.setAttribute('aria-expanded', isOpen);
-        navToggle.setAttribute('aria-label', isOpen ? 'Cerrar menú' : 'Abrir menú');
-      });
-      navLinks.forEach(link => link.addEventListener('click', () => {
-        if (nav.classList.contains('open')) {
-          nav.classList.remove('open');
-          navToggle.setAttribute('aria-expanded', 'false');
-          navToggle.setAttribute('aria-label', 'Abrir menú');
-        }
-      }));
+      const menuToggle = document.querySelector('.menu-toggle');
+      const mobileMenu = document.getElementById('primary-nav');
+      if (menuToggle && mobileMenu) {
+        const navLinks = mobileMenu.querySelectorAll('a');
+        menuToggle.addEventListener('click', () => {
+          const isOpen = mobileMenu.classList.toggle('open');
+          menuToggle.setAttribute('aria-expanded', isOpen);
+          menuToggle.setAttribute('aria-label', isOpen ? 'Cerrar menú de navegación' : 'Abrir menú de navegación');
+        });
+        navLinks.forEach(link => link.addEventListener('click', () => {
+          if (mobileMenu.classList.contains('open')) {
+            mobileMenu.classList.remove('open');
+            menuToggle.setAttribute('aria-expanded', 'false');
+            menuToggle.setAttribute('aria-label', 'Abrir menú de navegación');
+          }
+        }));
+      }
       // Modal legales
       const legalModal = document.getElementById('legal-modal');
       const abrirLegal = () => {

--- a/style.css
+++ b/style.css
@@ -13,7 +13,6 @@ revisame entero el codigo html { scroll-behavior: smooth; }
   --ok: #22c55e;
   --pill-bg: #e5e7eb;
   --pill-border: #e5e7eb;
-  --header-height: 120px;
 }
 
 * {
@@ -131,83 +130,110 @@ main section + section {
 /* ============================
    HEADER GENERAL (PC + global)
    ============================ */
+
 .site-header {
-  grid-area: header;
-  position: static;     /* NO FIJO */
-  top: auto;
-  inset-inline: 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: clamp(12px, 2vw, 20px) clamp(18px, 4vw, 32px);
+  margin-bottom: clamp(12px, 3vw, 20px);
   background: rgba(255, 255, 255, 0.96);
   backdrop-filter: saturate(180%) blur(16px);
   border-bottom: 1px solid var(--border);
   box-shadow: 0 6px 20px rgba(11, 47, 107, 0.05);
   border-radius: 0 0 18px 18px;
-  padding: clamp(12px, 2vw, 20px) clamp(18px, 4vw, 32px);
-  margin-bottom: clamp(12px, 3vw, 20px);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
   z-index: 999;
 }
 
-/* ===========================================
-   AJUSTE PARA MOVIL — eliminar barra fija
-   pero mantener logo + menú + modo oscuro
-   =========================================== */
-@media (max-width: 768px) {
-
-  .site-header {
-    position: static !important;
-    top: auto !important;
-    background: transparent !important;
-    box-shadow: none !important;
-    border-bottom: none !important;
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
-    margin-bottom: 0 !important;
-  }
-
-  :root {
-    --header-height: 0px !important;
-  }
-
-  .theme-toggle {
-    margin-top: 12px !important;
-    align-self: center !important;
-  }
-
-  .nav {
-    background: transparent !important;
-    border-top: none !important;
-    box-shadow: none !important;
-    top: 0 !important;
-  }
-
-  .nav-toggle {
-    visibility: visible !important;
-    pointer-events: auto !important;
-    display: inline-flex !important;
-    align-items: center;
-    justify-content: center;
-  }
-}
-
-/* ← ESTE CIERRE FALTABA */
-
-
-.header-top {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
+.header-left {
+  display: flex;
   align-items: center;
-  gap: 16px;
-  width: 100%;
+  gap: 12px;
+  flex-shrink: 0;
 }
 
 .header-actions {
   display: flex;
   align-items: center;
   gap: 12px;
-  justify-content: flex-end;
-  flex-wrap: wrap;
+  margin-left: auto;
+}
+
+.menu-toggle {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.menu-toggle span {
+  display: block;
+  height: 3px;
+  width: 100%;
+  background: #0B2F6B;
+  border-radius: 4px;
+}
+
+.mobile-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 12px);
+  left: clamp(18px, 4vw, 32px);
+  right: clamp(18px, 4vw, 32px);
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  padding: 20px;
+  z-index: 998;
+}
+
+.mobile-menu.open {
+  display: block;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links li {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.nav-links li:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.nav-links a {
+  color: var(--text);
+  font-weight: 600;
+  text-decoration: none;
+  font-size: 0.95rem;
+  padding: 12px 14px;
+  border-radius: 10px;
+  text-align: center;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-links a:hover {
+  background: var(--pill-bg);
+  border: 1px solid var(--pill-border);
+  color: #111111;
 }
 
 .header-cta {
@@ -270,58 +296,6 @@ main section + section {
   color: #22c55e;
 }
 
-.nav {
-  grid-area: nav;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-}
-.nav-links {
-  list-style: none;
-  display: flex;
-  gap: 16px;
-}
-
-.nav-links a {
-  color: var(--text);
-  font-weight: 600;
-  text-decoration: none;
-  font-size: 0.95rem;
-  padding: 8px 10px;
-  border-radius: 10px;
-  transition: background 0.2s ease, color 0.2s ease;
-}
-
-.nav-links a:hover {
-  background: var(--pill-bg);
-  border: 1px solid var(--pill-border);
-  color: #111111;
-}
-/* FIX menú hamburguesa limpio */
-.nav-toggle {
-  background: none !important;
-  border: none !important;
-  padding: 0 !important;
-  width: 32px !important;
-  height: 32px !important;
-  display: flex !important;
-  flex-direction: column !important;
-  justify-content: center !important;
-  gap: 5px !important;
-  cursor: pointer;
-  visibility: visible !important;
-  pointer-events: auto !important;
-}
-
-.nav-toggle-bar {
-  width: 100% !important;
-  height: 3px !important;
-  background-color: #0B2F6B !important;
-  border-radius: 3px !important;
-  margin: 0 !important;
-}
-
 .header-contact {
   font-size: 0.95rem;
   color: var(--muted);
@@ -338,102 +312,42 @@ main section + section {
   font-weight: 700;
 }
 
-@media (min-width: 769px) {
-  .nav-toggle {
-    visibility: hidden;
-    pointer-events: none;
-    display: none;
+@media (max-width: 768px) {
+  .site-header {
+    margin-bottom: 0;
   }
 }
 
-@media (max-width: 768px) {
-  .site-header {
-    padding: 16px 18px;
-    gap: 16px;
-  }
-
-  .header-top {
-    grid-template-columns: 1fr;
-    gap: 12px;
-    justify-items: center;
-  }
-
-  .header-actions {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .header-cta {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .nav-toggle {
-    visibility: visible;
-    pointer-events: auto;
-    justify-self: start;
-  }
-
-  .logo {
-    font-size: 1.45rem;
-  }
-
-  .header-actions {
-    flex-direction: column;
+@media (min-width: 769px) {
+  .mobile-menu {
+    display: flex !important;
+    position: static;
     align-items: center;
-    width: 100%;
-    gap: 8px;
-  }
-
-  .theme-toggle {
-    align-self: center;
-  }
-
-  .header-contact {
-    order: -1;
-    width: 100%;
-    text-align: center;
-    font-size: 0.9rem;
-    background: rgba(34, 197, 94, 0.12);
-    white-space: normal;
-  }
-
-  .nav {
-    position: fixed;
-    left: 0;
-    right: 0;
-    top: var(--header-height);
-    background: rgba(255, 255, 255, 0.98);
-    transform: translateY(-120%);
-    transition: transform 0.25s ease;
-    height: calc(100vh - var(--header-height));
-    overflow-y: auto;
-    border-top: 1px solid var(--border);
-    padding: 24px 16px 32px;
-    box-shadow: 0 18px 30px rgba(15, 23, 42, 0.12);
-  }
-
-  .nav.open {
-    transform: translateY(0);
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    margin-left: clamp(24px, 6vw, 48px);
   }
 
   .nav-links {
-    flex-direction: column;
-    padding: 0;
-    gap: 10px;
+    flex-direction: row;
+    align-items: center;
+    gap: 16px;
   }
 
   .nav-links li {
-    width: 100%;
-    border-top: 1px solid var(--border);
-    padding-top: 10px;
+    border: none;
+    padding-top: 0;
   }
 
   .nav-links a {
-    padding: 12px 14px;
-    display: block;
-    text-align: center;
-    font-size: 1.02rem;
+    padding: 8px 10px;
+    text-align: left;
+  }
+
+  .menu-toggle {
+    display: none;
   }
 }
 
@@ -1274,11 +1188,11 @@ body.dark-mode .nav-links a:hover {
   color: #22c55e;
 }
 
-body.dark-mode .nav {
+body.dark-mode .mobile-menu {
   background: #0b2f6b;
 }
 
-body.dark-mode .nav-toggle-bar {
+body.dark-mode .menu-toggle span {
   background: #ffffff;
 }
 
@@ -1311,7 +1225,7 @@ body.dark-mode .header-contact a {
   color: #86efac;
 }
 
-body.dark-mode .nav-toggle {
+body.dark-mode .menu-toggle {
   background: rgba(15, 23, 42, 0.85);
   border-color: #1f2937;
 }


### PR DESCRIPTION
## Summary
- restructure the header markup so the logo, navigation, and theme toggle sit in predictable positions without the phone number
- restyle the hamburger button and mobile menu so the icon renders properly and the dropdown opens and closes cleanly
- update the menu script to toggle the new classes and aria attributes when users open or close the navigation

## Testing
- No automated tests were run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c0cdf2bc8320af8ce125ab65a894)