### PR TITLE
Adjust mobile banner CTA styling and link

### DIFF
--- a/index.html
+++ b/index.html
@@ -531,7 +531,7 @@
   <!-- BANNER MÓVIL -->
   <div id="mobile-banner" class="mobile-banner">
     <span>¿Quieres que revisemos tu factura?</span>
-    <a href="/whatsapp.html" class="btn btn-primary mobile-banner-btn" aria-label="Enviar factura por WhatsApp">Solicitar revisión</a>
+    <a href="https://wa.me/34953818494?text=Hola%2C%20me%20gustar%C3%ADa%20solicitar%20la%20revisi%C3%B3n%20de%20mi%20factura%20y%20un%20estudio%20energ%C3%A9tico%20certificado." class="btn btn-primary mobile-banner-btn" aria-label="Enviar factura por WhatsApp" rel="noopener">Solicitar revisión</a>
     <button id="close-banner" class="mobile-banner-close" aria-label="Cerrar banner móvil">Cerrar</button>
   </div>
   <!-- BOTÓN WHATSAPP -->

--- a/style.css
+++ b/style.css
@@ -490,11 +490,11 @@ main section + section {
   right: 0;
   background: #22c55e;
   color: #ffffff;
-  padding: 7px 16px;
+  padding: 4px 12px;
   z-index: 9999;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
 }
 
 .mobile-banner.is-visible {
@@ -502,20 +502,20 @@ main section + section {
 }
 
 .mobile-banner span {
-  font-size: 0.95rem;
+  font-size: 0.88rem;
 }
 
 .mobile-banner-btn {
   margin: 0;
-  padding: 8px 16px;
-  font-size: 0.95rem;
+  padding: 6px 14px;
+  font-size: 0.88rem;
 }
 
 .mobile-banner-close {
   background: none;
   border: none;
   color: #ffffff;
-  font-size: 1rem;
+  font-size: 0.9rem;
   cursor: pointer;
 }
 
@@ -1759,29 +1759,29 @@ body.dark-mode .fab-wa {
 
 /* Compact mobile banner adjustments */
 .mobile-banner {
-  padding: 6px 14px;
-  min-height: 52px;
-  gap: 10px;
+  padding: 4px 12px;
+  min-height: 44px;
+  gap: 8px;
 }
 
 .mobile-banner span {
-  font-size: 0.88rem;
-  line-height: 1.25;
+  font-size: 0.86rem;
+  line-height: 1.3;
 }
 
 .mobile-banner-btn {
-  padding: 0 16px;
-  min-height: 36px;
+  padding: 0 14px;
+  min-height: 32px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.88rem;
+  font-size: 0.86rem;
   border-radius: 999px;
 }
 
 .mobile-banner-close {
-  font-size: 0.9rem;
-  padding: 4px 6px;
+  font-size: 0.85rem;
+  padding: 2px 6px;
 }
 
 @media (max-width: 560px) {


### PR DESCRIPTION
## Summary
- update the mobile banner CTA to link directly to WhatsApp with a prefilled message
- tighten the banner spacing and typography so it occupies less vertical space

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c906ee188320aa40e2954c0f30b5)