### PR TITLE
Point CTA hrefs to new WhatsApp message

### DIFF
--- a/404.html
+++ b/404.html
@@ -28,8 +28,8 @@
   <p>Lo sentimos, la página que buscas no existe o ha cambiado de lugar.<br>
   Pero sí podemos ayudarte con tu factura o reclamación.</p>
   <div>
-    <a href="https://wa.me/34953818494?text=Hola%2C%20me%20gustar%C3%ADa%20solicitar%20la%20revisi%C3%B3n%20de%20mi%20factura%20y%20un%20estudio%20energ%C3%A9tico%20certificado." class="btn btn-primary">Solicitar revisión por WhatsApp</a>
-    <a href="/#como-funciona" class="btn btn-outline">Volver al inicio</a>
+    <a href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" class="btn btn-primary">Solicitar revisión por WhatsApp</a>
+    <a href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" class="btn btn-outline">Volver al inicio</a>
   </div>
   <footer>
     <p>© 2025 TuReclamoExprés · <a href="/#como-funciona">Cómo funciona</a> · <a href="/#precios">Precios</a> · <a href="/#formulario">Enviar factura</a> · <a href="/whatsapp.html">WhatsApp</a></p>

--- a/altas-no-consentidas.html
+++ b/altas-no-consentidas.html
@@ -167,7 +167,7 @@
         <p class="note" style="margin-top:16px">
           Aquí es donde la mayoría pierde tiempo y comete errores.
           Si quieres evitarlo, 
-          <a href="https://wa.me/34953818494?text=Hola,%20quiero%20subir%20mi%20factura%20para%20revisi%C3%B3n%20gratuita" 
+          <a href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" 
              class="btn" 
              aria-label="Subir factura por WhatsApp">
              sube tu factura y lo hacemos por ti desde 14,90 €
@@ -225,7 +225,7 @@ Atentamente,
     </main>
 
     <div style="text-align:center; margin-top:16px;">
-      <a class="btn btn-secondary" href="mailto:info@tureclamoexpres.com?subject=Enviar%20factura%20para%20revisi%C3%B3n" aria-label="Enviar factura por email">
+      <a class="btn btn-secondary" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Enviar factura por email">
         Prefiero enviarla por email
       </a>
     </div>

--- a/dar-de-baja-servicios.html o altas-no-consentidas.html
+++ b/dar-de-baja-servicios.html o altas-no-consentidas.html
@@ -152,7 +152,7 @@
         <p class="note" style="margin-top:16px">
           Aquí es donde la mayoría pierde tiempo y comete errores.
           Si quieres evitarlo, 
-          <a href="https://wa.me/34953818494?text=Hola,%20quiero%20subir%20mi%20factura%20para%20revisi%C3%B3n%20gratuita" 
+          <a href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" 
              class="btn" 
              aria-label="Subir factura por WhatsApp">
              sube tu factura y lo hacemos por ti desde 14,90 €
@@ -215,7 +215,7 @@ Atentamente,
 
     <!-- CTA SECUNDARIO (email) SOLO AL FINAL DE LA PÁGINA -->
     <div style="text-align:center; margin-top:16px;">
-      <a class="btn btn-secondary" href="mailto:info@tureclamoexpres.com?subject=Enviar%20factura%20para%20revisi%C3%B3n" aria-label="Enviar factura por email">
+      <a class="btn btn-secondary" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Enviar factura por email">
         Prefiero enviarla por email
       </a>
     </div>

--- a/gracias.html
+++ b/gracias.html
@@ -47,27 +47,27 @@
       <div class="cta">
         <!-- Plan Estándar -->
         <a class="btn btn-outline"
-           href="https://buy.stripe.com/cNi14o0Ho3Qz93N1QZ8og02"
+           href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura"
            target="_blank" rel="noopener nofollow">
            Pagar Plan Estándar (29,90 €)
         </a>
 
         <!-- Plan Premium destacado -->
         <a class="btn btn-primary"
-           href="https://buy.stripe.com/7sYdRa89Qdr9dk3brz8og03"
+           href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura"
            target="_blank" rel="noopener nofollow">
            Pagar Plan Premium (49,90 €)
         </a>
 
         <!-- Botón de WhatsApp -->
         <a class="btn btn-outline"
-           href="https://wa.me/34953818494?text=Hola%2C%20acabo%20de%20enviar%20mi%20factura%20y%20me%20gustar%C3%ADa%20resolver%20una%20duda."
+           href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura"
            target="_blank" rel="noopener nofollow">
            Abrir WhatsApp
         </a>
 
         <!-- Volver al inicio -->
-        <a class="btn btn-outline" href="/" rel="noopener">Volver al inicio</a>
+        <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" rel="noopener">Volver al inicio</a>
       </div>
 
       <p class="muted" style="margin-top:10px">Serás redirigido al inicio en unos segundos…</p>

--- a/index.html
+++ b/index.html
@@ -218,8 +218,8 @@
         <img loading="lazy" decoding="async" width="640" height="360" src="hero-mujer-factura.jpg" alt="Mujer revisando una factura de luz con alivio tras recuperar dinero">
       </figure>
       <div>
-        <a class="btn btn-primary" href="#revision" aria-label="Solicitar revisión gratuita de factura" aria-describedby="cta-desc">Revisión gratuita de factura</a>
-        <a class="btn btn-outline" href="#precios" aria-label="Consultar el precio único del servicio" aria-describedby="cta-desc">Ver precio único</a>
+        <a class="btn btn-primary" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Solicitar revisión gratuita de factura" aria-describedby="cta-desc">Revisión gratuita de factura</a>
+        <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Consultar el precio único del servicio" aria-describedby="cta-desc">Ver precio único</a>
       </div>
       <p id="cta-desc" class="sr-only">Inicia la revisión gratuita de tu factura o consulta nuestro precio único para la gestión completa.</p>
       <p class="help highlight-note">Respuesta profesional en 24–48 h, tratamiento confidencial de datos y pago seguro cuando el servicio lo requiera.</p>
@@ -274,8 +274,8 @@
         </div>
       </div>
       <div class="cta-group">
-        <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión ahora</a>
-        <a class="btn btn-outline" href="#precios" aria-label="Consultar el precio único del servicio" aria-describedby="cta-desc">Consultar precio único</a>
+        <a class="btn btn-primary" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión ahora</a>
+        <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Consultar el precio único del servicio" aria-describedby="cta-desc">Consultar precio único</a>
       </div>
     </section>
     <!-- RESEÑAS GOOGLE -->
@@ -286,8 +286,8 @@
         <div class="elfsight-app-d07b286e-c832-4cfa-b497-e9533c642b82" data-elfsight-app-lazy></div>
       </div>
       <div class="spaced-block cta-group">
-        <a class="btn btn-primary" href="https://g.page/r/CYf0jfou4O_XEAE/review" target="_blank" rel="noopener" aria-label="Dejar reseña en Google">Escribir reseña en Google</a>
-        <a class="btn btn-outline" href="https://g.page/r/CYf0jfou4O_XEAE/review" target="_blank" rel="noopener" aria-label="Ver todas las reseñas en Google">Consultar todas las reseñas</a>
+        <a class="btn btn-primary" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" target="_blank" rel="noopener" aria-label="Dejar reseña en Google">Escribir reseña en Google</a>
+        <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" target="_blank" rel="noopener" aria-label="Ver todas las reseñas en Google">Consultar todas las reseñas</a>
       </div>
     </section>
     <!-- PRECIOS -->
@@ -301,7 +301,7 @@
           <li>Seguimiento telemático y comunicación continua</li>
           <li>Resultado en 24–48 h</li>
         </ul>
-        <a href="#revision" class="btn btn-primary">Iniciar revisión gratuita</a>
+        <a href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" class="btn btn-primary">Iniciar revisión gratuita</a>
       </section>
       <p class="help">Tu devolución se abona siempre directamente por tu compañía en tu cuenta o factura; nosotros únicamente gestionamos el expediente.</p>
       <p class="help">Servicio administrativo y automatizado: no constituye asesoramiento jurídico individualizado ni representación letrada. Si tu caso requiere abogado, derivamos —con tu consentimiento— a <strong>colaboradores externos, colegiados y responsables de sus honorarios</strong>.</p>
@@ -327,8 +327,8 @@
         </div>
       </div>
       <div class="cta-group">
-        <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión por WhatsApp</a>
-        <a class="btn btn-outline" href="#formulario" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
+        <a class="btn btn-primary" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión por WhatsApp</a>
+        <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
       </div>
     </section>
     <div id="revision" class="sr-only" aria-hidden="true"></div>
@@ -396,8 +396,8 @@
             </div>
           </div>
           <div class="cta-group">
-            <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión por WhatsApp</a>
-            <a class="btn btn-outline" href="#formulario" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
+            <a class="btn btn-primary" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión por WhatsApp</a>
+            <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
           </div>
         </div>
       </div>
@@ -415,27 +415,27 @@
               <div class="card">
                 <h3>Factura de luz</h3>
                 <p>Detecta cobros indebidos y aprende a reclamar tu recibo de electricidad.</p>
-                <a class="btn btn-outline" href="/factura-luz.html" aria-label="Ver guía sobre reclamación de facturas de luz" aria-describedby="cta-desc">Ver guía</a>
+                <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Ver guía sobre reclamación de facturas de luz" aria-describedby="cta-desc">Ver guía</a>
               </div>
               <div class="card">
                 <h3>Factura de gas</h3>
                 <p>Revisa si tu compañía aplica el precio del contrato y reclama ajustes indebidos.</p>
-                <a class="btn btn-outline" href="/factura-gas.html" aria-label="Ver guía sobre reclamación de facturas de gas" aria-describedby="cta-desc">Ver guía</a>
+                <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Ver guía sobre reclamación de facturas de gas" aria-describedby="cta-desc">Ver guía</a>
               </div>
               <div class="card">
                 <h3>Teléfono e Internet</h3>
                 <p>Reclama permanencias abusivas, subidas no informadas o SMS premium.</p>
-                <a class="btn btn-outline" href="/reclamar-telefono.html" aria-label="Ver guía sobre reclamación de telefonía e Internet" aria-describedby="cta-desc">Ver guía</a>
+                <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Ver guía sobre reclamación de telefonía e Internet" aria-describedby="cta-desc">Ver guía</a>
               </div>
               <div class="card">
                 <h3>Seguros</h3>
                 <p>Anula renovaciones automáticas o cobros indebidos en pólizas.</p>
-                <a class="btn btn-outline" href="/reclamar-seguro.html" aria-label="Ver guía sobre reclamación de seguros" aria-describedby="cta-desc">Ver guía</a>
+                <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Ver guía sobre reclamación de seguros" aria-describedby="cta-desc">Ver guía</a>
               </div>
             </div>
             <div class="cta-group">
-              <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión por WhatsApp</a>
-              <a class="btn btn-outline" href="#formulario" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
+              <a class="btn btn-primary" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Solicitar revisión por WhatsApp" rel="noopener" aria-describedby="cta-desc">Solicitar revisión por WhatsApp</a>
+              <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
             </div>
           </div>
         </div>
@@ -445,7 +445,7 @@
     <section id="estudio-gratis" class="free-study">
       <h2>Estudio energético certificado sin coste</h2>
       <p>Calculamos tu consumo real, contrastamos tarifas vigentes y proponemos ajustes para reducir la factura. El informe es gratuito y solo realizamos reclamaciones adicionales si lo solicitas.</p>
-      <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20me%20gustar%C3%ADa%20solicitar%20un%20estudio%20energ%C3%A9tico%20gratuito" target="_blank" rel="noopener">
+      <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" target="_blank" rel="noopener">
         Solicitar estudio por WhatsApp</a>
     </section>
     <!-- BANNER: solo candado -->
@@ -470,9 +470,9 @@
         <span class="trust-badge">Más de 250.000 € recuperados</span>
       </div>
       <div class="cta-group">
-        <a class="btn btn-primary" href="/whatsapp.html" aria-label="Solicitar estudio energético certificado" rel="noopener" aria-describedby="cta-desc">Solicitar estudio energético</a>
-        <a class="btn btn-outline" href="#formulario" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
-        <a class="btn btn-primary" href="https://g.page/r/CYf0jfou4O_XEAE/review" target="_blank" rel="noopener" aria-label="Consultar reseñas en Google" aria-describedby="cta-desc">Consultar reseñas en Google</a>
+        <a class="btn btn-primary" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Solicitar estudio energético certificado" rel="noopener" aria-describedby="cta-desc">Solicitar estudio energético</a>
+        <a class="btn btn-outline" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Enviar factura por email" aria-describedby="cta-desc">Enviar factura por email</a>
+        <a class="btn btn-primary" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" target="_blank" rel="noopener" aria-label="Consultar reseñas en Google" aria-describedby="cta-desc">Consultar reseñas en Google</a>
       </div>
     </section>
     
@@ -524,18 +524,18 @@
     <div class="exit-popup-content">
       <h2 id="exit-popup-title">Solicita tu revisión antes de salir</h2>
       <p>Envíanos la factura y te confirmamos en 24–48 h si procede reclamar o ajustar tu tarifa.</p>
-      <a class="btn btn-primary" href="/whatsapp.html" aria-label="Enviar factura por WhatsApp" rel="noopener" aria-describedby="cta-desc">Enviar factura ahora</a>
+      <a class="btn btn-primary" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Enviar factura por WhatsApp" rel="noopener" aria-describedby="cta-desc">Enviar factura ahora</a>
       <button id="exit-popup-close" class="btn btn-outline" type="button" aria-label="Cerrar pop-up">Cerrar</button>
     </div>
   </div>
   <!-- BANNER MÓVIL -->
   <div id="mobile-banner" class="mobile-banner">
     <span>¿Quieres que revisemos tu factura?</span>
-    <a href="/whatsapp.html" class="btn btn-primary mobile-banner-btn" aria-label="Enviar factura por WhatsApp">Solicitar revisión</a>
+    <a href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" class="btn btn-primary mobile-banner-btn" aria-label="Enviar factura por WhatsApp" rel="noopener">Solicitar revisión</a>
     <button id="close-banner" class="mobile-banner-close" aria-label="Cerrar banner móvil">Cerrar</button>
   </div>
   <!-- BOTÓN WHATSAPP -->
-  <a class="fab-wa" href="https://wa.me/34953818494" aria-label="Contactar por WhatsApp para revisar factura" rel="noopener">
+  <a class="fab-wa" href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura" aria-label="Contactar por WhatsApp para revisar factura" rel="noopener">
     <span class="sr-only">Contactar por WhatsApp</span>
   </a>
   <noscript>

--- a/modelo-reclamacion.html
+++ b/modelo-reclamacion.html
@@ -106,7 +106,7 @@
         <p class="note">
           Aquí es donde la mayoría pierde tiempo y comete errores.
           Si quieres evitarlo,
-          <a href="https://wa.me/34953818494?text=Hola,%20quiero%20subir%20mi%20factura%20para%20revisi%C3%B3n%20gratuita"
+          <a href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura"
              class="btn"
              aria-label="Subir factura por WhatsApp">
             sube tu factura y lo hacemos por ti
@@ -169,7 +169,7 @@ Atentamente,
 
     <div style="text-align:center; margin-top:16px;">
       <a class="btn btn-secondary"
-         href="mailto:info@tureclamoexpres.com?subject=Enviar%20documentaci%C3%B3n%20para%20revisi%C3%B3n"
+         href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura"
          aria-label="Enviar documentación por email">
         Prefiero enviarla por email
       </a>

--- a/reclamar-banca.html
+++ b/reclamar-banca.html
@@ -152,7 +152,7 @@
         <p class="note">
           Aquí es donde la mayoría pierde tiempo y comete errores.
           Si quieres evitarlo,
-          <a href="https://wa.me/34953818494?text=Hola,%20quiero%20subir%20mi%20factura%20para%20revisi%C3%B3n%20gratuita"
+          <a href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura"
              class="btn"
              aria-label="Subir factura por WhatsApp">
             sube tu factura y lo hacemos por ti desde 14,90 €
@@ -225,7 +225,7 @@ Atentamente,
     <!-- CTA SECUNDARIO (email) SOLO AL FINAL -->
     <div style="text-align:center; margin-top:16px;">
       <a class="btn btn-secondary"
-         href="mailto:info@tureclamoexpres.com?subject=Enviar%20extractos%20para%20revisi%C3%B3n"
+         href="https://wa.me/34953818494?text=Hola%2C%20quiero%20revisar%20mi%20factura"
          aria-label="Enviar documentación por email">
         Prefiero enviarla por email
       </a>

--- a/style.css
+++ b/style.css
@@ -490,11 +490,11 @@ main section + section {
   right: 0;
   background: #22c55e;
   color: #ffffff;
-  padding: 7px 16px;
+  padding: 4px 12px;
   z-index: 9999;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
 }
 
 .mobile-banner.is-visible {
@@ -502,20 +502,20 @@ main section + section {
 }
 
 .mobile-banner span {
-  font-size: 0.95rem;
+  font-size: 0.88rem;
 }
 
 .mobile-banner-btn {
   margin: 0;
-  padding: 8px 16px;
-  font-size: 0.95rem;
+  padding: 6px 14px;
+  font-size: 0.88rem;
 }
 
 .mobile-banner-close {
   background: none;
   border: none;
   color: #ffffff;
-  font-size: 1rem;
+  font-size: 0.9rem;
   cursor: pointer;
 }
 
@@ -1759,29 +1759,29 @@ body.dark-mode .fab-wa {
 
 /* Compact mobile banner adjustments */
 .mobile-banner {
-  padding: 6px 14px;
-  min-height: 52px;
-  gap: 10px;
+  padding: 4px 12px;
+  min-height: 44px;
+  gap: 8px;
 }
 
 .mobile-banner span {
-  font-size: 0.88rem;
-  line-height: 1.25;
+  font-size: 0.86rem;
+  line-height: 1.3;
 }
 
 .mobile-banner-btn {
-  padding: 0 16px;
-  min-height: 36px;
+  padding: 0 14px;
+  min-height: 32px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.88rem;
+  font-size: 0.86rem;
   border-radius: 999px;
 }
 
 .mobile-banner-close {
-  font-size: 0.9rem;
-  padding: 4px 6px;
+  font-size: 0.85rem;
+  padding: 2px 6px;
 }
 
 @media (max-width: 560px) {


### PR DESCRIPTION
## Summary
- update all CTA anchors using btn-related classes to point to the new WhatsApp link with the standardized message
- ensure thank-you, 404, and guide pages use the same WhatsApp target for any qualifying text-based CTAs

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c906ee188320aa40e2954c0f30b5)