### PR TITLE
Add legal pages and update Energia footer links

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Aviso Legal | TuReclamoExprés</title>
+  <meta name="description" content="Aviso legal y datos identificativos de TuReclamoExprés.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="legal-page">
+  <header class="header" role="banner">
+    <div class="logo">
+      <a href="/" aria-label="Volver a la página principal de TuReclamoExprés">
+        <img src="logo.jfif" alt="TuReclamoExprés" />
+      </a>
+    </div>
+    <nav aria-label="Navegación principal">
+      <a href="/" class="btn btn-outline">Inicio</a>
+      <a href="/energia.html" class="btn btn-primary">EnergíaExprés</a>
+    </nav>
+  </header>
+
+  <main class="legal" role="main">
+    <header>
+      <h1>Aviso Legal</h1>
+      <p>Información legal de TuReclamoExprés y datos identificativos del titular.</p>
+    </header>
+
+    <section>
+      <p>Este sitio es titularidad de S.A.G. Servicios Digitales.</p>
+      <p><strong>Objeto:</strong> información general y modelos automatizados de reclamación, sin que ello suponga asesoramiento jurídico ni representación letrada.</p>
+      <p>En supuestos que requieran intervención de abogado, podremos derivar —con consentimiento expreso del usuario— a <strong>abogados colaboradores externos, colegiados y responsables de sus honorarios y actuaciones</strong>.</p>
+      <p>A efectos meramente identificativos y de contacto interno del titular del proyecto, se hace constar —sin perjuicio de la razón social anterior— que <em>Sergio Arnes Gómez, DNI 78687563D, C/ Ibañez Marín, Andújar (Jaén), C.P. 23740</em>, participa en la coordinación operativa del servicio, dejando claro que cualquier controversia se someterá a los Juzgados y Tribunales de Jaén, salvo lo dispuesto por normativa de consumidores.</p>
+    </section>
+  </main>
+
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-top">
+      <div>
+        <h3>TuReclamoExprés</h3>
+        <p>Revisión gratuita y reclamaciones exprés de facturas.</p>
+      </div>
+      <div class="footer-links">
+        <a href="/">Inicio</a>
+        <a href="/#precios">Precios</a>
+        <a href="/#guias">Guías</a>
+        <a href="/whatsapp.html">WhatsApp</a>
+        <a href="/energia.html">Energía</a>
+      </div>
+      <div class="footer-contact">
+        <a href="tel:+34953818494">+34 953 818 494</a>
+        <a href="https://wa.me/34953818494">https://wa.me/34953818494</a>
+        <a href="mailto:info@tureclamoexpres.com">info@tureclamoexpres.com</a>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>© 2025 TuReclamoExprés</span>
+      <a href="/politica-privacidad.html">Política de privacidad</a>
+      <a href="/aviso-legal.html">Aviso legal</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/energia.html
+++ b/energia.html
@@ -276,8 +276,8 @@
     </div>
     <div class="footer-bottom">
       <span>© 2025 TuReclamoExprés</span>
-      <a href="/politica-privacidad">Política de privacidad</a>
-      <a href="/aviso-legal">Aviso legal</a>
+      <a href="/politica-privacidad.html">Política de privacidad</a>
+      <a href="/aviso-legal.html">Aviso legal</a>
     </div>
   </footer>
 

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Política de Privacidad | TuReclamoExprés</title>
+  <meta name="description" content="Política de privacidad y protección de datos de TuReclamoExprés.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="legal-page">
+  <header class="header" role="banner">
+    <div class="logo">
+      <a href="/" aria-label="Volver a la página principal de TuReclamoExprés">
+        <img src="logo.jfif" alt="TuReclamoExprés" />
+      </a>
+    </div>
+    <nav aria-label="Navegación principal">
+      <a href="/" class="btn btn-outline">Inicio</a>
+      <a href="/energia.html" class="btn btn-primary">EnergíaExprés</a>
+    </nav>
+  </header>
+
+  <main class="legal" role="main">
+    <header>
+      <h1>Política de Privacidad</h1>
+      <p>Información sobre cómo tratamos tus datos en TuReclamoExprés.</p>
+    </header>
+
+    <section>
+      <p>En virtud del RGPD y la LOPDGDD, los datos que los usuarios remitan vía formularios, correo o servicios vinculados se tratarán con la finalidad de revisión gratuita de facturas, elaboración de diagnósticos preliminares y, en su caso, generación y entrega de documentos automatizados.</p>
+      <p><strong>Responsable:</strong> S.A.G. Servicios Digitales. <strong>Contacto:</strong> <a href="mailto:info@tureclamoexpres.com">info@tureclamoexpres.com</a>.</p>
+      <p>No se cederán datos a terceros salvo obligación legal o necesidad técnica en modalidad de gestión completa. El usuario puede ejercer sus derechos de acceso, rectificación, supresión, oposición, limitación y portabilidad mediante solicitud al correo indicado.</p>
+    </section>
+
+    <section>
+      <h2>Cookies</h2>
+      <p>Este sitio utiliza únicamente cookies técnicas imprescindibles. Puntualmente podrían usarse cookies analíticas de terceros (p. ej., Google Analytics) previo consentimiento del usuario. Puedes bloquear o eliminar cookies en tu navegador; algunas funciones podrían verse limitadas.</p>
+    </section>
+
+    <section>
+      <h2>Condiciones del servicio</h2>
+      <p>El acceso al sitio implica la aceptación de estas condiciones. El servicio consiste en la revisión inicial gratuita, identificación de cobros indebidos y, en su caso, generación de documentos automatizados que el usuario puede enviar por sí mismo o autorizar su envío en modalidad de gestión completa.</p>
+      <p>La prestación es administrativa y automatizada; no constituye asesoramiento jurídico individualizado ni representación letrada. Precios IVA incluido, pago a través de Stripe. Al ser contenido digital de entrega inmediata, no aplica derecho de desistimiento (art. 103.m TRLGDCU), sin perjuicio de reembolso por incidencias técnicas.</p>
+    </section>
+  </main>
+
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-top">
+      <div>
+        <h3>TuReclamoExprés</h3>
+        <p>Revisión gratuita y reclamaciones exprés de facturas.</p>
+      </div>
+      <div class="footer-links">
+        <a href="/">Inicio</a>
+        <a href="/#precios">Precios</a>
+        <a href="/#guias">Guías</a>
+        <a href="/whatsapp.html">WhatsApp</a>
+        <a href="/energia.html">Energía</a>
+      </div>
+      <div class="footer-contact">
+        <a href="tel:+34953818494">+34 953 818 494</a>
+        <a href="https://wa.me/34953818494">https://wa.me/34953818494</a>
+        <a href="mailto:info@tureclamoexpres.com">info@tureclamoexpres.com</a>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>© 2025 TuReclamoExprés</span>
+      <a href="/politica-privacidad.html">Política de privacidad</a>
+      <a href="/aviso-legal.html">Aviso legal</a>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated política de privacidad and aviso legal pages with existing legal content and site styling
- update EnergíaExprés footer links to point to the new legal pages to avoid 404s

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923961067348320b3ac5eb85cb1c1f8)